### PR TITLE
Fix plugin theme context and add multi-icon example

### DIFF
--- a/examples/site/docs/gentamicin.mdx
+++ b/examples/site/docs/gentamicin.mdx
@@ -1,0 +1,13 @@
+---
+id: gentamicin
+slug: /antibiotics/gentamicin
+synonyms:
+  - Genta
+  - Gentamicin
+icon: syringe
+shortNote: "Broad-spectrum aminoglycoside, IV/IM dosing with renal monitoring."
+---
+
+# Gentamicin
+
+Gentamicin is an aminoglycoside antibiotic used to treat serious Gram-negative infections. Therapeutic drug monitoring is recommended to avoid nephrotoxicity.

--- a/examples/site/docs/smartlink-demo.mdx
+++ b/examples/site/docs/smartlink-demo.mdx
@@ -3,5 +3,5 @@ id: smartlink-demo
 title: SmartLink Demo
 ---
 
-This demo shows how terms like Amoxi automatically link to their reference page.
+This demo shows how terms like Amoxi and Genta automatically link to their reference pages.
 

--- a/examples/site/docusaurus.config.ts
+++ b/examples/site/docusaurus.config.ts
@@ -42,7 +42,11 @@ const config: Config = {
   ],
   plugins: [
     ['@linkify-med/docusaurus-plugin', {
-      icons: { pill: 'emoji:💊' }
+      icons: {
+        pill: 'emoji:💊',
+        syringe: '/img/syringe.svg',
+      },
+      iconProps: { width: 16, height: 16 },
     }]
   ],
 };

--- a/examples/site/static/img/syringe.svg
+++ b/examples/site/static/img/syringe.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M7 17l10-10" />
+  <path d="M7 11l6-6" />
+  <path d="M11 15l6-6" />
+  <path d="M5 19l2-2" />
+  <path d="M18 6l-2-2" />
+  <path d="M3 21l3-3" />
+  <path d="M14 4l2 2" />
+  <path d="M2 16l6 6" />
+</svg>

--- a/packages/docusaurus-plugin-linkify-med/src/index.ts
+++ b/packages/docusaurus-plugin-linkify-med/src/index.ts
@@ -1,3 +1,5 @@
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import type { Plugin } from '@docusaurus/types';
 import type { LoadContext, PluginContentLoadedActions } from '@docusaurus/types';
 import { validateOptions, type PluginOptions, type NormalizedOptions } from './options';
@@ -18,6 +20,10 @@ type Content = {
   registryFile: string;
   opts: NormalizedOptions;
 };
+
+const moduleDirname = dirname(fileURLToPath(import.meta.url));
+const themePath = join(moduleDirname, '../src/theme');
+const tsThemePath = themePath;
 
 export default function linkifyMedPlugin(_context: LoadContext, optsIn?: PluginOptions): Plugin<Content> {
   const { options: normOpts } = validateOptions(optsIn);
@@ -52,7 +58,11 @@ export default function linkifyMedPlugin(_context: LoadContext, optsIn?: PluginO
     },
 
     getThemePath() {
-      return './src/theme';
+      return themePath;
+    },
+
+    getTypeScriptThemePath() {
+      return tsThemePath;
     },
 
     getClientModules() {

--- a/packages/docusaurus-plugin-linkify-med/src/theme/MDXComponents.tsx
+++ b/packages/docusaurus-plugin-linkify-med/src/theme/MDXComponents.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import MDXComponents from '@theme-original/MDXComponents';
+import MDXComponents from '@theme-init/MDXComponents';
 import SmartLink from '@theme/SmartLink';
 
 export default {

--- a/packages/docusaurus-plugin-linkify-med/src/theme/Root.tsx
+++ b/packages/docusaurus-plugin-linkify-med/src/theme/Root.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
-import Root from '@theme-original/Root';
+import Root from '@theme-init/Root';
 import useGlobalData from '@docusaurus/useGlobalData';
 import { IconConfigProvider, LinkifyRegistryProvider } from './context';
 import { createIconResolver, type NormalizedOptions } from '../options';
-import { registry } from '@generated/docusaurus-plugin-linkify-med/registry';
+import { registry } from '@generated/docusaurus-plugin-linkify-med/default/registry';
 import './styles.css';
 
 type GlobalData = { options: NormalizedOptions };

--- a/packages/docusaurus-plugin-linkify-med/src/theme/docusaurus-shims.d.ts
+++ b/packages/docusaurus-plugin-linkify-med/src/theme/docusaurus-shims.d.ts
@@ -8,12 +8,12 @@ declare module '@theme/SmartLink' {
   export default SmartLink;
 }
 
-declare module '@theme-original/MDXComponents' {
+declare module '@theme-init/MDXComponents' {
   const MDXComponents: Record<string, any>;
   export default MDXComponents;
 }
 
-declare module '@theme-original/Root' {
+declare module '@theme-init/Root' {
   import type { ReactNode } from 'react';
   const Root: React.ComponentType<{ children?: ReactNode }>;
   export default Root;

--- a/packages/docusaurus-plugin-linkify-med/src/theme/generated.d.ts
+++ b/packages/docusaurus-plugin-linkify-med/src/theme/generated.d.ts
@@ -1,4 +1,4 @@
-declare module '@generated/docusaurus-plugin-linkify-med/registry' {
+declare module '@generated/docusaurus-plugin-linkify-med/default/registry' {
   export const registry: Record<string, any>;
 }
 


### PR DESCRIPTION
## Summary
- fix the plugin's theme wiring so Docusaurus resolves the context providers from the source theme directory and references the correct @theme-init fallbacks
- update the MDX theme bridge to use @theme-init and provide TypeScript shims for the new module specifiers
- extend the example site with a syringe SVG icon, new Gentamicin doc, and updated SmartLink demo text to showcase multiple icon sources

## Testing
- pnpm --filter @linkify-med/docusaurus-plugin test
- CI=1 pnpm site:build

------
https://chatgpt.com/codex/tasks/task_e_68c84a60ef348331ad43e72affee9107