### PR TITLE
Add TypeScript theme path getter

### DIFF
--- a/packages/docusaurus-plugin-linkify-med/src/index.ts
+++ b/packages/docusaurus-plugin-linkify-med/src/index.ts
@@ -66,6 +66,10 @@ export default function linkifyMedPlugin(_context: LoadContext, optsIn?: PluginO
       return join(moduleDir, 'theme', 'runtime');
     },
 
+    getTypeScriptThemePath() {
+      return join(moduleDir, 'theme');
+    },
+
     getClientModules() {
       return [join(moduleDir, 'theme/styles.css')];
     },


### PR DESCRIPTION
## Summary
- add a `getTypeScriptThemePath` implementation returning the source theme directory for editors

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68c96222c5f483318ded781ea990d792