### PR TITLE
Align theme runtime with MDX provider and icon handling

### DIFF
--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -644,3 +644,17 @@ Refactored the example site's remark integration to use a pure ESM import of `re
 - `pnpm -r --filter './packages/**' run build`
 - `pnpm -r run test`
 - `pnpm --filter @examples/site run build`
+
+# Fix: align theme runtime with evaluation feedback
+
+## Summary
+
+- Added ThemedImage + useBaseUrl handling to the runtime IconResolver so light/dark assets and baseUrl work consistently.
+- Updated the short note emitter to forward MDXProvider context instead of forcing an empty components map and wired tests + mocks accordingly.
+- Removed the example site's SmartLink override now that the plugin theme publishes MDX components globally.
+
+## Verification
+
+- `pnpm -r --filter './packages/**' run build`
+- `pnpm -r --filter './packages/**' run test`
+- `pnpm site:build`

--- a/examples/site/src/theme/MDXComponents.tsx
+++ b/examples/site/src/theme/MDXComponents.tsx
@@ -1,8 +1,0 @@
-import React from 'react';
-import MDXComponents from '@theme-original/MDXComponents';
-import SmartLink from '@linkify-med/docusaurus-plugin/theme/SmartLink';
-
-export default {
-  ...MDXComponents,
-  SmartLink,
-};

--- a/packages/docusaurus-plugin-linkify-med/src/codegen/notesEmitter.ts
+++ b/packages/docusaurus-plugin-linkify-med/src/codegen/notesEmitter.ts
@@ -58,9 +58,10 @@ ${esm}
 
 // Stable wrapper API expected by the theme:
 export function ShortNote(props) {
-  const components = props?.components ?? {};
+  const { components, ...rest } = props ?? {};
+  const mdxProps = components ? { components, ...rest } : rest;
   // MDXContent is the default export from the compiled MDX above
-  return React.createElement(MDXContent, { components });
+  return React.createElement(MDXContent, mdxProps);
 }
 `.trimStart();
 

--- a/packages/docusaurus-plugin-linkify-med/src/pluginName.ts
+++ b/packages/docusaurus-plugin-linkify-med/src/pluginName.ts
@@ -1,1 +1,2 @@
 export const PLUGIN_NAME = 'docusaurus-plugin-linkify-med';
+export const DEFAULT_PLUGIN_ID = 'default';

--- a/packages/docusaurus-plugin-linkify-med/src/theme/docusaurus-shims.d.ts
+++ b/packages/docusaurus-plugin-linkify-med/src/theme/docusaurus-shims.d.ts
@@ -3,6 +3,10 @@ declare module '@docusaurus/useGlobalData' {
   export function usePluginData<T = any>(pluginName: string): T;
 }
 
+declare module '@docusaurus/useBaseUrl' {
+  export default function useBaseUrl(path?: string | null): string;
+}
+
 declare module '@mdx-js/react' {
   import type { ReactNode, ComponentType } from 'react';
   export interface MDXProviderProps {
@@ -21,5 +25,14 @@ declare module '@theme-init/Root' {
   import type { ReactNode } from 'react';
   const Root: React.ComponentType<{ children?: ReactNode }>;
   export default Root;
+}
+
+declare module '@theme/ThemedImage' {
+  import type { ComponentType, ImgHTMLAttributes } from 'react';
+  export interface ThemedImageProps extends ImgHTMLAttributes<HTMLImageElement> {
+    sources: { light: string; dark?: string };
+  }
+  const ThemedImage: ComponentType<ThemedImageProps>;
+  export default ThemedImage;
 }
 

--- a/packages/docusaurus-plugin-linkify-med/src/theme/runtime/IconResolver.tsx
+++ b/packages/docusaurus-plugin-linkify-med/src/theme/runtime/IconResolver.tsx
@@ -1,4 +1,6 @@
 import React from 'react';
+import useBaseUrl from '@docusaurus/useBaseUrl';
+import ThemedImage from '@theme/ThemedImage';
 import { IconConfigContext } from './context.js';
 
 export interface IconResolverProps extends Omit<React.ImgHTMLAttributes<HTMLImageElement>, 'id' | 'src' | 'alt'> {
@@ -11,16 +13,13 @@ export default function IconResolver({ iconId, className, ...rest }: IconResolve
   const api = React.useContext(IconConfigContext);
   if (!iconId || !api) return null;
 
-  // naive prefers-light; could read prefers-color-scheme if needed
-  const mode: 'light' | 'dark' =
-    typeof window !== 'undefined' && window.matchMedia?.('(prefers-color-scheme: dark)').matches
-      ? 'dark'
-      : 'light';
-  const src = api.resolveIconSrc(iconId, mode);
-  if (!src) return null;
+  const lightSrcRaw = api.resolveIconSrc(iconId, 'light');
+  const darkSrcRaw = api.resolveIconSrc(iconId, 'dark');
+  const primarySrc = lightSrcRaw ?? darkSrcRaw;
+  if (!primarySrc) return null;
 
-  if (src.startsWith('emoji:')) {
-    const emoji = src.slice('emoji:'.length);
+  if (primarySrc.startsWith('emoji:')) {
+    const emoji = primarySrc.slice('emoji:'.length);
     return (
       <span
         className={['lm-icon', 'lm-icon-emoji', className].filter(Boolean).join(' ')}
@@ -32,13 +31,28 @@ export default function IconResolver({ iconId, className, ...rest }: IconResolve
     );
   }
 
-  return (
-    <img
-      src={src}
-      className={['lm-icon', className].filter(Boolean).join(' ')}
-      aria-hidden="true"
-      {...(api.iconProps ?? {})}
-      {...rest}
-    />
-  );
+  const lightSrc = lightSrcRaw ? useBaseUrl(lightSrcRaw) : undefined;
+  const darkSrc = darkSrcRaw ? useBaseUrl(darkSrcRaw) : undefined;
+  const fallbackSrc = lightSrc ?? darkSrc;
+  if (!fallbackSrc) return null;
+
+  const baseClassName = ['lm-icon', className].filter(Boolean).join(' ');
+  const sharedImageProps = {
+    className: baseClassName,
+    'aria-hidden': 'true' as const,
+    ...(api.iconProps ?? {}),
+    ...rest,
+  };
+
+  if (darkSrc && darkSrc !== fallbackSrc) {
+    return (
+      <ThemedImage
+        sources={{ light: fallbackSrc, dark: darkSrc }}
+        alt=""
+        {...sharedImageProps}
+      />
+    );
+  }
+
+  return <img src={fallbackSrc} alt="" {...sharedImageProps} />;
 }

--- a/packages/docusaurus-plugin-linkify-med/src/theme/runtime/Root.tsx
+++ b/packages/docusaurus-plugin-linkify-med/src/theme/runtime/Root.tsx
@@ -6,10 +6,7 @@ import { IconConfigProvider, LinkifyRegistryProvider, type LinkifyRegistry } fro
 import SmartLink from './SmartLink.js';
 import { createIconResolver, type NormalizedOptions } from '../../options.js';
 import { PLUGIN_NAME } from '../../pluginName.js';
-import {
-  registry as generatedRegistry,
-  type GeneratedRegistryEntry,
-} from '@generated/docusaurus-plugin-linkify-med/default/registry';
+import { generatedRegistry, type GeneratedRegistryEntry } from './generatedRegistry.js';
 
 const pluginName = PLUGIN_NAME;
 const EMPTY_OPTIONS: NormalizedOptions = { icons: {} };

--- a/packages/docusaurus-plugin-linkify-med/src/theme/runtime/generatedRegistry.ts
+++ b/packages/docusaurus-plugin-linkify-med/src/theme/runtime/generatedRegistry.ts
@@ -1,0 +1,15 @@
+import {
+  registry as generatedRegistry,
+  type GeneratedRegistryEntry,
+} from '@generated/docusaurus-plugin-linkify-med/default/registry';
+
+/**
+ * The generated registry lives under the plugin name + plugin id.
+ * The default id is exported from pluginName.ts; if you customize the id,
+ * make sure to duplicate this module with the matching import path so
+ * Docusaurus can statically resolve the generated data.
+ */
+export const GENERATED_REGISTRY_IMPORT_PATH =
+  '@generated/docusaurus-plugin-linkify-med/default/registry';
+
+export { generatedRegistry, type GeneratedRegistryEntry };

--- a/packages/docusaurus-plugin-linkify-med/tests/mocks/ThemedImage.tsx
+++ b/packages/docusaurus-plugin-linkify-med/tests/mocks/ThemedImage.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+type Props = {
+  sources: { light: string; dark?: string };
+} & React.ImgHTMLAttributes<HTMLImageElement>;
+
+export default function ThemedImage({ sources, ...rest }: Props) {
+  const { light, dark } = sources;
+  const src = light ?? dark ?? '';
+  return <img src={src} data-light={light ?? ''} data-dark={dark ?? ''} {...rest} />;
+}

--- a/packages/docusaurus-plugin-linkify-med/tests/mocks/useBaseUrl.ts
+++ b/packages/docusaurus-plugin-linkify-med/tests/mocks/useBaseUrl.ts
@@ -1,0 +1,3 @@
+export default function useBaseUrl(path?: string | null) {
+  return path ?? '';
+}

--- a/packages/docusaurus-plugin-linkify-med/tests/notesEmitter.test.ts
+++ b/packages/docusaurus-plugin-linkify-med/tests/notesEmitter.test.ts
@@ -46,7 +46,8 @@ describe('emitShortNoteModule', () => {
     expect(mod).not.toBeNull();
     // Should reference MDXContent and accept components prop
     expect(mod!.contents).toMatch(/React\.createElement\(MDXContent/);
-    expect(mod!.contents).toContain('const components = props?.components ?? {};');
+    expect(mod!.contents).toContain('const { components, ...rest } = props ?? {};');
+    expect(mod!.contents).toContain('const mdxProps = components ? { components, ...rest } : rest;');
     const tr = transpiles(mod!.contents);
     expect(tr.ok).toBe(true);
   });

--- a/packages/docusaurus-plugin-linkify-med/tests/theme.smartlink.test.tsx
+++ b/packages/docusaurus-plugin-linkify-med/tests/theme.smartlink.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import SmartLink from '../src/theme/runtime/SmartLink.js';
@@ -94,20 +94,20 @@ describe('SmartLink (theme)', () => {
   });
 
   it('icon resolver uses dark/light paths', () => {
-    // pretend dark mode
-    Object.defineProperty(window, 'matchMedia', {
-      writable: true,
-      value: (query: string) => ({
-        matches: query.includes('prefers-color-scheme: dark'),
-        media: query, addEventListener() {}, removeEventListener() {}, onchange: null, addListener() {}, removeListener() {}
-      })
+    const resolveIconSrc = vi.fn((id: string, mode: 'light' | 'dark') => `/img/${id}-${mode}.svg`);
+
+    const { container } = setup(<SmartLink to="/x" icon="pill">Amoxi</SmartLink>, {
+      registry: {},
+      iconApi: { resolveIconSrc, iconProps: { width: 14, height: 14 } },
     });
 
-    setup(<SmartLink to="/x" icon="pill">Amoxi</SmartLink>, {
-      registry: {}
-    });
-    const img = screen.getByRole('img', { hidden: true }) as HTMLImageElement;
-    expect(img.src).toMatch('/img/pill-dark.svg');
+    expect(resolveIconSrc).toHaveBeenCalledWith('pill', 'light');
+    expect(resolveIconSrc).toHaveBeenCalledWith('pill', 'dark');
+
+    const img = container.querySelector('img.lm-icon') as HTMLImageElement;
+    expect(img).toBeTruthy();
+    expect(img.dataset.light).toBe('/img/pill-light.svg');
+    expect(img.dataset.dark).toBe('/img/pill-dark.svg');
   });
 
   it('renders emoji when icon resolves to emoji string', () => {

--- a/packages/docusaurus-plugin-linkify-med/vitest.config.ts
+++ b/packages/docusaurus-plugin-linkify-med/vitest.config.ts
@@ -13,7 +13,9 @@ export default defineConfig({
     alias: {
       '@theme-init/Root': resolve(__dirname, 'tests/mocks/RootStub.tsx'),
       '@docusaurus/useGlobalData': resolve(__dirname, 'tests/mocks/useGlobalData.ts'),
+      '@docusaurus/useBaseUrl': resolve(__dirname, 'tests/mocks/useBaseUrl.ts'),
       '@mdx-js/react': resolve(__dirname, 'tests/mocks/mdx.tsx'),
+      '@theme/ThemedImage': resolve(__dirname, 'tests/mocks/ThemedImage.tsx'),
       '@generated/docusaurus-plugin-linkify-med/default/registry': resolve(
         __dirname,
         'tests/mocks/generatedRegistry.ts'


### PR DESCRIPTION
## Summary
- use Docusaurus' ThemedImage plus useBaseUrl in the runtime icon resolver to support light/dark assets and base URLs
- forward MDX provider context from emitted short notes and extend tests/mocks for the new runtime wiring
- centralize the generated registry import and drop the example site's SmartLink override now that the plugin supplies it globally

## Testing
- pnpm -r --filter './packages/**' run build
- pnpm -r --filter './packages/**' run test
- pnpm site:build

------
https://chatgpt.com/codex/tasks/task_e_68c9614772848331af866c530d749d7e