### PR TITLE
Revamp example docs and redirect homepage

### DIFF
--- a/examples/site/docs/cdiff.mdx
+++ b/examples/site/docs/cdiff.mdx
@@ -7,8 +7,32 @@ synonyms:
 icon: bug
 shortNote: |
   **Anaerobic pathogen.** Spore-forming Gram-positive rod.
+sidebar_position: 3
 ---
 
 # Clostridioides difficile
 
 Clostridioides difficile is a spore-forming anaerobe often abbreviated as Cdiff.
+In the demo dataset it represents how pathogen alerts can be woven into everyday
+clinical documentation.
+
+:::danger Transmission risk
+Cdiff spores persist in the environment and can spread rapidly across inpatient units.
+Early detection in free-text notes helps infection-control teams respond quickly.
+:::
+
+## Auto-link behaviour
+
+- Any mention of **Cdiff** or the full organism name links here for deeper guidance.
+- The inline preview highlights that it is an anaerobic, Gram-positive rod.
+- Icons attached to the link draw attention to the infection risk level.
+
+## Response checklist
+
+1. Initiate contact precautions immediately when Cdiff is suspected.
+2. Send stool samples for toxin assay confirmation.
+3. Review current antimicrobial therapy — especially agents such as Amoxicillin
+   that predispose patients to Cdiff infection.
+
+These steps show how automatic linking keeps situational awareness high without
+burdening authors with formatting work.

--- a/examples/site/docs/linkify-test.mdx
+++ b/examples/site/docs/linkify-test.mdx
@@ -4,8 +4,43 @@ slug: /antibiotics/amoxicillin
 synonyms: [Amoxi]
 icon: pill
 shortNote: "**Aminopenicillin** p.o./i.v."
+sidebar_position: 2
 ---
 
-# Linkify Test
+# Amoxicillin reference
 
-Amoxi is transformed. Amoxicillin is also transformed.
+Amoxicillin is one of the standard examples used by the plugin to demonstrate
+how drug monographs can be cross-linked without manual HTML.
+
+:::note Quick summary
+**Class:** Aminopenicillin  \\
+**Administration routes:** Oral or intravenous  \\
+**Auto-link triggers:** Amoxi, Amoxicillin
+:::
+
+## Typical auto-link triggers
+
+- Clinical shorthand such as **Amoxi** in a discharge note.
+- The full name **Amoxicillin** inside therapeutic guidelines.
+- Mentions embedded in a dosage table or formulary export.
+
+Whenever a match is detected, the text becomes an interactive link that reuses
+this document's metadata and iconography.
+
+## Example scenario
+
+A pediatric rounding note that reads "Continue Amoxi for 5 days" will automatically
+link to this page, giving prescribers fast access to dosage adjustments.
+If the same patient develops symptoms concerning for Cdiff, the note will
+feature two contextual links: one for the antibiotic and one for the pathogen profile.
+
+## Additional metadata
+
+| Property | Value |
+| --- | --- |
+| Spectrum | Gram-positive coverage with limited Gram-negative activity |
+| Adjustment | Required in renal impairment |
+| Related organisms | *Helicobacter pylori*, *Streptococcus pneumoniae* |
+
+These details illustrate how the plugin can surface quick facts directly from the
+knowledge graph while keeping authors focused on the clinical narrative.

--- a/examples/site/docs/overview.mdx
+++ b/examples/site/docs/overview.mdx
@@ -1,0 +1,71 @@
+---
+id: overview
+title: Explore Auto-Link Examples
+sidebar_position: 1
+description: Discover different ways the Linkify-Med plugin transforms medical content into rich cross-linked knowledge.
+---
+
+import Link from '@docusaurus/Link';
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+# Explore Auto-Link Examples
+
+The Linkify-Med plugin automatically turns free text into a connected knowledge base.
+This page highlights several ways the demo content reacts when the plugin is enabled.
+
+:::info Live demo content
+Every example on this page uses the same vocabulary configuration that powers the plugin.
+Each highlighted term is transformed into a contextual link when the page renders.
+:::
+
+## Use cases at a glance
+
+<Tabs groupId="usecase">
+  <TabItem value="antibiotic" label="Antibiotic monographs">
+    Clinicians browsing dosing information can jump straight into the
+    <Link to="/docs/antibiotics/amoxicillin">Amoxicillin reference</Link> by
+    clicking either **Amoxicillin** or its common abbreviation **Amoxi** inside
+    any note or guideline.
+  </TabItem>
+  <TabItem value="pathogen" label="Pathogen warnings">
+    Infection-control teams are warned when **Clostridioides difficile** is
+    mentioned.
+    The plugin links every occurrence of the bacterium — even the shortened
+    **Cdiff** form — to the <Link to="/docs/bacteria/cdiff">pathogen sheet</Link>.
+  </TabItem>
+  <TabItem value="smart" label="SmartLink walkthrough">
+    Training material such as the <Link to="/docs/smartlink-demo">SmartLink demo</Link>
+    shows how both organisms and drugs become interactive without adding manual
+    markup to the source documents.
+  </TabItem>
+</Tabs>
+
+## Inline auto-link demo
+
+As soon as content writers mention Amoxi for a patient, the plugin resolves it to the
+complete Amoxicillin entry.
+If a lab report later confirms Clostridioides difficile, the same note contains a
+link to up-to-date treatment guidelines — no additional authoring steps required.
+
+:::tip Hover the links
+Hovering a linked word displays the rich preview configured for that concept.
+Try it on either **Amoxicillin** or **Cdiff** in this section to see the inline metadata.
+:::
+
+## Vocabulary overview
+
+| Term in text | Destination document | Recognized synonyms |
+| --- | --- | --- |
+| Amoxicillin | [Antibiotic profile](/docs/antibiotics/amoxicillin) | Amoxi |
+| Clostridioides difficile | [Pathogen overview](/docs/bacteria/cdiff) | Cdiff, *Clostridioides difficile* |
+| SmartLink Demo | [Tutorial walkthrough](/docs/smartlink-demo) | SmartLink demo |
+
+## Continue exploring
+
+- Dive into the [antibiotic profile](/docs/antibiotics/amoxicillin) to inspect the
+  structured notes and icons the plugin injects.
+- Review the [pathogen overview](/docs/bacteria/cdiff) to see how warnings appear
+  for high-risk organisms.
+- Follow the [SmartLink walkthrough](/docs/smartlink-demo) to understand how any
+  content source can benefit from automatic linking.

--- a/examples/site/docs/smartlink-demo.mdx
+++ b/examples/site/docs/smartlink-demo.mdx
@@ -1,6 +1,30 @@
 ---
 id: smartlink-demo
 title: SmartLink Demo
+sidebar_position: 4
 ---
 
-This demo shows how terms like Amoxi and Cdiff automatically link to their reference pages.
+# SmartLink Demo
+
+This walkthrough illustrates how a single paragraph referencing Amoxi and Cdiff is
+instantly upgraded with contextual links.
+
+## Step-by-step tour
+
+1. Authors write natural language instructions that mention treatments and pathogens.
+2. The Linkify-Med plugin scans the text, matching terms such as **Amoxicillin** or **Cdiff**.
+3. Matching phrases are wrapped with rich links that surface icons, quick notes, and
+   shortcut navigation to deeper documentation.
+
+:::tip No manual markup required
+The underlying Markdown files remain clean. The plugin injects links and previews
+on the fly based on your vocabulary configuration.
+:::
+
+## Combined example
+
+> Continue Amoxi for 5 days and monitor closely for signs of Clostridioides difficile.
+
+In the published site, the snippet above produces two interactive anchors — one for the
+antibiotic and another for the infection. Readers can then jump into the related
+reference sheets for dosing recommendations or infection-control protocols.

--- a/examples/site/src/pages/index.md
+++ b/examples/site/src/pages/index.md
@@ -1,7 +1,0 @@
----
-title: Home
----
-
-# Linkify-Med Example Site
-
-This is a minimal Docusaurus v3 site used to validate monorepo builds.

--- a/examples/site/src/pages/index.mdx
+++ b/examples/site/src/pages/index.mdx
@@ -1,0 +1,10 @@
+---
+title: Home
+---
+
+import {Redirect} from '@docusaurus/router';
+import Link from '@docusaurus/Link';
+
+<Redirect to="/docs/overview" />
+
+If you are not redirected automatically, open the <Link to="/docs/overview">example overview</Link> to explore the live demos.


### PR DESCRIPTION
## Summary
- add an overview document that showcases Linkify-Med use cases, inline demos, and navigation cues
- expand the antibiotic, pathogen, and SmartLink docs with richer content and sidebar ordering
- redirect the example homepage to the new overview so visitors land directly in the docs experience

## Testing
- pnpm --filter site build

------
https://chatgpt.com/codex/tasks/task_e_68c9864eed308331bc95f55a601fbe18