### PR TITLE
Add styling and swizzle guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,40 @@ The Docusaurus theme now ships from the compiled `dist/theme` directory.  All ru
 
 The plugin exposes its CSS via `getClientModules()`.  When the plugin is enabled Docusaurus automatically loads `dist/theme/styles.css`, no manual stylesheet import is required.
 
+## Styling & Swizzle
+
+Override the default look and feel by targeting the SmartLink and tooltip hooks from a site-level stylesheet such as `src/css/custom.css`.
+
+```css
+/* src/css/custom.css */
+:root {
+  --lm-tooltip-bg: #1d1f4f;
+}
+
+.lm-tooltip-content {
+  background: var(--lm-tooltip-bg);
+  color: var(--ifm-color-white);
+  border-radius: 0.75rem;
+  padding: 0.5rem 0.75rem;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+}
+
+.lm-tooltip-arrow {
+  fill: var(--lm-tooltip-bg);
+}
+
+.lm-smartlink__iconwrap {
+  display: none;
+}
+```
+
+For deeper React customisations swizzle the runtime components and wire in your own versions.  The SmartLink and Tooltip entry points are exposed by the plugin:
+
+```bash
+npx docusaurus swizzle docusaurus-plugin-linkify-med Tooltip
+npx docusaurus swizzle docusaurus-plugin-linkify-med SmartLink
+```
+
 ## Swizzle notes
 
 Consumers can still swizzle `@theme/SmartLink` or `@theme/Tooltip` for custom behaviour.  The plugin’s context providers live in `@theme/Root`; swizzled components should read from `IconConfigContext` and `LinkifyRegistryContext` to stay aligned with the generated registry.


### PR DESCRIPTION
## Summary
- document Styling & Swizzle guidance in the README
- include sample CSS overrides and swizzle commands for SmartLink and Tooltip

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c9881afc14833183e656f35d549980