### PR TITLE
Include page title as synonym in index

### DIFF
--- a/packages/docusaurus-plugin-linkify-med/src/frontmatter.ts
+++ b/packages/docusaurus-plugin-linkify-med/src/frontmatter.ts
@@ -46,6 +46,77 @@ function normalizeSynonyms(list: unknown): string[] | null {
   return uniq.length ? uniq : null;
 }
 
+function cleanHeadingText(text: string): string {
+  let t = text.trim();
+  if (!t) return '';
+  t = t.replace(/\s+#+\s*$/, '');
+  t = t.replace(/\s*\{#.+\}\s*$/, '');
+  t = t.replace(/\[([^\]]+)\]\([^\)]+\)/g, '$1');
+  t = t.replace(/`([^`]+)`/g, '$1');
+  t = t.replace(/\*\*([^*]+)\*\*/g, '$1');
+  t = t.replace(/__([^_]+)__/g, '$1');
+  t = t.replace(/\*([^*]+)\*/g, '$1');
+  t = t.replace(/_([^_]+)_/g, '$1');
+  t = t.replace(/~~([^~]+)~~/g, '$1');
+  t = t.replace(/<\/?.+?>/g, '');
+  t = t.replace(/\s+/g, ' ');
+  return t.trim();
+}
+
+function extractFirstHeadingTitle(body: string): string {
+  if (!body) return '';
+  const lines = body.split(/\r?\n/);
+  let inFence = false;
+  for (const raw of lines) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line.startsWith('```') || line.startsWith('~~~')) {
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) continue;
+    const match = /^#{1,6}\s+(.+)$/.exec(line);
+    if (match) {
+      const cleaned = cleanHeadingText(match[1]);
+      if (cleaned) return cleaned;
+    }
+  }
+  return '';
+}
+
+function capitalizeWord(word: string): string {
+  if (!word) return '';
+  if (word.length === 1) return word.toLocaleUpperCase();
+  return word[0].toLocaleUpperCase() + word.slice(1);
+}
+
+function slugToTitle(slug: string): string {
+  const trimmed = slug.trim();
+  if (!trimmed) return '';
+  const parts = trimmed.split('/').filter(Boolean);
+  if (!parts.length) return '';
+  const last = parts[parts.length - 1] ?? '';
+  const base = last.replace(/\.[^./]+$/, '');
+  if (!base) return '';
+  const segments = base.split(/[-_]/).filter(Boolean);
+  if (!segments.length) {
+    return capitalizeWord(base);
+  }
+  const words = segments.map(capitalizeWord).filter(Boolean);
+  const candidate = words.join(' ').trim();
+  return candidate || capitalizeWord(base);
+}
+
+function pushUnique(list: string[], seen: Set<string>, value: string | undefined): void {
+  if (typeof value !== 'string') return;
+  const trimmed = value.trim();
+  if (!trimmed) return;
+  const key = trimmed.toLocaleLowerCase();
+  if (seen.has(key)) return;
+  seen.add(key);
+  list.push(trimmed);
+}
+
 export function parseFrontmatter(files: RawDocFile[]): FrontmatterParseResult {
   const entries: IndexRawEntry[] = [];
   const warnings: FrontmatterWarning[] = [];
@@ -61,7 +132,7 @@ export function parseFrontmatter(files: RawDocFile[]): FrontmatterParseResult {
     }
 
     try {
-      const { data } = matter(file.content ?? '');
+      const { data, content: bodyContent } = matter(file.content ?? '');
       const res = FM.safeParse(data ?? {});
       if (!res.success) {
         warnings.push({
@@ -124,12 +195,27 @@ export function parseFrontmatter(files: RawDocFile[]): FrontmatterParseResult {
         continue;
       }
 
-      const title = typeof fm.title === 'string' ? fm.title.trim() : '';
-      const lowerSynonyms = new Set(normalizedSynonyms.map(s => s.toLocaleLowerCase()));
-      const synonyms =
-        title && !lowerSynonyms.has(title.toLocaleLowerCase())
-          ? [title, ...normalizedSynonyms]
-          : normalizedSynonyms;
+      const explicitTitle = typeof fm.title === 'string' ? fm.title.trim() : '';
+      const headingTitle = explicitTitle ? '' : extractFirstHeadingTitle(bodyContent ?? '');
+      const canonicalTitle = explicitTitle || headingTitle;
+      const canonicalTitleLower = canonicalTitle ? canonicalTitle.toLocaleLowerCase() : '';
+      const slugTitle = slug ? slugToTitle(slug) : '';
+
+      const seenSynonyms = new Set<string>();
+      const synonyms: string[] = [];
+
+      pushUnique(synonyms, seenSynonyms, canonicalTitle);
+
+      if (slugTitle) {
+        const slugLower = slugTitle.toLocaleLowerCase();
+        if (!canonicalTitleLower || canonicalTitleLower.startsWith(slugLower)) {
+          pushUnique(synonyms, seenSynonyms, slugTitle);
+        }
+      }
+
+      for (const syn of normalizedSynonyms) {
+        pushUnique(synonyms, seenSynonyms, syn);
+      }
 
       const shortRaw = typeof fm.shortNote === 'string' ? fm.shortNote.trim() : '';
       const shortNote = shortRaw ? shortRaw : undefined;

--- a/packages/docusaurus-plugin-linkify-med/tests/frontmatter.test.ts
+++ b/packages/docusaurus-plugin-linkify-med/tests/frontmatter.test.ts
@@ -34,7 +34,7 @@ describe('frontmatter loader (raw)', () => {
     const vanco = entries.find(e => e.id === 'vancomycin')!;
     expect(vanco.icon).toBeUndefined();
     expect(vanco.shortNote).toBeUndefined();
-    expect(vanco.synonyms).toEqual(['Vanco', 'Vancomycinum']);
+    expect(vanco.synonyms).toEqual(['Vancomycin', 'Vanco', 'Vancomycinum']);
 
     // Warnings: linkify:false, missing id, empty synonyms, bad slug, non-array synonyms
     const codes = warnings.map(w => w.code).sort();
@@ -83,5 +83,28 @@ describe('frontmatter loader (raw)', () => {
 
     expect(withTitle?.synonyms).toEqual(['Canonical Name', 'Alias']);
     expect(withDuplicate?.synonyms).toEqual(['Already There']);
+  });
+
+  it('derives the title from the first heading and adds slug-based canonical matches', () => {
+    const files: RawDocFile[] = [
+      {
+        path: '/docs/amox-heading.mdx',
+        content: [
+          '---',
+          'id: amox-heading',
+          'slug: /antibiotics/amoxicillin',
+          'synonyms: [Amoxi]',
+          '---',
+          '',
+          '# Amoxicillin reference',
+          '',
+          'Body'
+        ].join('\n')
+      }
+    ];
+
+    const { entries } = loadIndexFromFiles(files);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]?.synonyms).toEqual(['Amoxicillin reference', 'Amoxicillin', 'Amoxi']);
   });
 });


### PR DESCRIPTION
## Summary
- include the page title in the synonym list when parsing frontmatter so SmartLink can link canonical titles
- add regression coverage to ensure titles are injected only once alongside custom synonyms

## Testing
- pnpm --filter @linkify-med/docusaurus-plugin test

------
https://chatgpt.com/codex/tasks/task_e_68c98b40cfec8331a598b9bcba604e24