### PR TITLE
Prevent self-linking and expose short note placeholder

### DIFF
--- a/packages/docusaurus-plugin-linkify-med/src/theme/index.ts
+++ b/packages/docusaurus-plugin-linkify-med/src/theme/index.ts
@@ -2,4 +2,5 @@ export { default as Root } from './runtime/Root.js';
 export { default as SmartLink } from './runtime/SmartLink.js';
 export { default as Tooltip } from './runtime/Tooltip.js';
 export { default as IconResolver } from './runtime/IconResolver.js';
+export { default as LinkifyShortNote } from './runtime/LinkifyShortNote.js';
 export * from './runtime/context.js';

--- a/packages/docusaurus-plugin-linkify-med/src/theme/runtime/LinkifyShortNote.tsx
+++ b/packages/docusaurus-plugin-linkify-med/src/theme/runtime/LinkifyShortNote.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { LinkifyRegistryContext } from './context.js';
+
+export interface LinkifyShortNoteProps {
+  tipKey?: string;
+  fallback?: React.ReactNode;
+  components?: Record<string, any>;
+}
+
+export default function LinkifyShortNote({ tipKey, fallback = null, components }: LinkifyShortNoteProps) {
+  const registry = React.useContext(LinkifyRegistryContext);
+  if (!tipKey) {
+    return fallback ?? null;
+  }
+
+  const entry = registry?.[tipKey];
+  const Short = entry?.ShortNote;
+  if (!Short) {
+    return fallback ?? null;
+  }
+
+  return <Short components={components} />;
+}

--- a/packages/docusaurus-plugin-linkify-med/src/theme/runtime/Root.tsx
+++ b/packages/docusaurus-plugin-linkify-med/src/theme/runtime/Root.tsx
@@ -4,6 +4,7 @@ import { usePluginData } from '@docusaurus/useGlobalData';
 import { MDXProvider } from '@mdx-js/react';
 import { IconConfigProvider, LinkifyRegistryProvider, type LinkifyRegistry } from './context.js';
 import SmartLink from './SmartLink.js';
+import LinkifyShortNote from './LinkifyShortNote.js';
 import { createIconResolver, type NormalizedOptions } from '../../options.js';
 import { PLUGIN_NAME } from '../../pluginName.js';
 import { generatedRegistry, type GeneratedRegistryEntry } from './generatedRegistry.js';
@@ -39,7 +40,7 @@ function Providers({ children }: { children: React.ReactNode }) {
   return (
     <IconConfigProvider api={iconApi}>
       <LinkifyRegistryProvider registry={registryValue}>
-        <MDXProvider components={{ SmartLink }}>{children}</MDXProvider>
+        <MDXProvider components={{ SmartLink, LinkifyShortNote }}>{children}</MDXProvider>
       </LinkifyRegistryProvider>
     </IconConfigProvider>
   );

--- a/packages/docusaurus-plugin-linkify-med/tests/theme.root.test.tsx
+++ b/packages/docusaurus-plugin-linkify-med/tests/theme.root.test.tsx
@@ -4,6 +4,7 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Root from '../src/theme/runtime/Root.js';
 import SmartLink from '../src/theme/runtime/SmartLink.js';
+import LinkifyShortNote from '../src/theme/runtime/LinkifyShortNote.js';
 import { PLUGIN_NAME } from '../src/pluginName.js';
 
 vi.mock('@theme-init/Root', () => ({
@@ -59,5 +60,16 @@ describe('theme Root provider', () => {
     const notes = await screen.findAllByTestId('shortnote');
     expect(notes.length).toBeGreaterThan(0);
     expect(notes[0]).toHaveTextContent('Short note!');
+  });
+
+  it('exposes LinkifyShortNote through the MDX provider', () => {
+    render(
+      <Root>
+        <LinkifyShortNote tipKey="amoxicillin" />
+      </Root>
+    );
+
+    const note = screen.getByTestId('shortnote');
+    expect(note).toHaveTextContent('Short note!');
   });
 });

--- a/packages/remark-linkify-med/tests/transform.test.ts
+++ b/packages/remark-linkify-med/tests/transform.test.ts
@@ -91,4 +91,22 @@ Some text with Amoxi.
     expect(out).toContain('to="/a"');
     expect(out).toContain('tipKey="a-amox"');
   });
+
+  it('skips linking synonyms on their own page', () => {
+    const tSelf: TargetInfo[] = [
+      { id: 'self', slug: '/docs/self', sourcePath: '/docs/current.mdx', synonyms: ['Self'] },
+      { id: 'other', slug: '/docs/other', sourcePath: '/docs/other.mdx', synonyms: ['Other'] },
+    ];
+    const out = run('Self meets Other.', tSelf);
+    expect(out).toContain('Self meets <SmartLink to="/docs/other" tipKey="other" match="Other">Other</SmartLink>.');
+    expect(out).not.toContain('to="/docs/self"');
+  });
+
+  it('replaces short note placeholder with LinkifyShortNote', () => {
+    const tSelf: TargetInfo[] = [
+      { id: 'self', slug: '/docs/self', sourcePath: '/docs/current.mdx', synonyms: ['Self'] },
+    ];
+    const out = run('Intro %%SHORT_NOTICE%% outro.', tSelf);
+    expect(out).toContain('Intro <LinkifyShortNote tipKey="self" /> outro.');
+  });
 });


### PR DESCRIPTION
## Summary
- skip autolinking matches that resolve to the current page and emit a LinkifyShortNote component when encountering the %%SHORT_NOTICE%% placeholder
- provide the LinkifyShortNote runtime component through the plugin theme so MDX can render inline short notes
- extend unit tests to cover self-link suppression, placeholder rendering, and runtime access to short notes

## Testing
- pnpm -r --filter './packages/**' run test
- pnpm -r --filter './packages/**' run build
- pnpm site:build

------
https://chatgpt.com/codex/tasks/task_e_68c99490c5f0833190f91f36fbaea21d