### PR TITLE
Improve dev frontmatter reloads

### DIFF
--- a/packages/docusaurus-plugin-linkify-med/src/frontmatter.ts
+++ b/packages/docusaurus-plugin-linkify-med/src/frontmatter.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import type {
   RawDocFile,
   FrontmatterParseResult,
+  FrontmatterParseFileResult,
   IndexRawEntry,
   FrontmatterWarning,
 } from './types.js';
@@ -39,128 +40,138 @@ function normalizeAutoLinkTerms(list: unknown[]): string[] {
   return terms;
 }
 
+export function parseFrontmatterFile(file: RawDocFile): FrontmatterParseFileResult {
+  const warnings: FrontmatterWarning[] = [];
+
+  if (!isSupportedExt(file.path, file.ext)) {
+    warnings.push({
+      path: file.path,
+      code: 'UNSUPPORTED_EXT',
+      message: 'Unsupported extension (only .md/.mdx are processed).'
+    });
+    return { warnings };
+  }
+
+  try {
+    const { data } = matter(file.content ?? '');
+    const res = FM.safeParse(data ?? {});
+    if (!res.success) {
+      warnings.push({
+        path: file.path,
+        code: 'INVALID_TYPE',
+        message: 'Frontmatter has invalid shape.',
+        details: { issues: res.error.issues.map(i => ({ path: i.path, message: i.message })) }
+      });
+      return { warnings };
+    }
+
+    const fm = res.data;
+
+    const linkify = fm.linkify ?? true;
+    if (!linkify) {
+      warnings.push({
+        path: file.path,
+        code: 'LINKIFY_FALSE',
+        message: '`linkify:false` – skipped from index.'
+      });
+      return { warnings };
+    }
+
+    const hasAutoLinkField = Object.prototype.hasOwnProperty.call(fm, 'auto-link');
+    const autoLinkRaw = (fm as any)['auto-link'];
+
+    if (!hasAutoLinkField || typeof autoLinkRaw === 'undefined') {
+      return { warnings };
+    }
+
+    if (!Array.isArray(autoLinkRaw)) {
+      warnings.push({
+        path: file.path,
+        code: 'INVALID_TYPE',
+        message: '`auto-link` must be an array of strings.'
+      });
+      return { warnings };
+    }
+
+    const terms = normalizeAutoLinkTerms(autoLinkRaw);
+    if (terms.length === 0) {
+      warnings.push({
+        path: file.path,
+        code: 'EMPTY_AUTO_LINK',
+        message: '`auto-link` must include at least one non-empty string.'
+      });
+      return { warnings };
+    }
+
+    const id = (fm.id ?? '').trim();
+    if (!id) {
+      warnings.push({
+        path: file.path,
+        code: 'EMPTY_ID',
+        message: 'Missing required `id`.'
+      });
+      return { warnings };
+    }
+
+    const slug = (fm.slug ?? '').trim();
+    if (!slug) {
+      warnings.push({
+        path: file.path,
+        code: 'EMPTY_SLUG',
+        message: 'Missing required `slug`.'
+      });
+      return { warnings };
+    }
+    if (!slug.startsWith('/')) {
+      warnings.push({
+        path: file.path,
+        code: 'INVALID_TYPE',
+        message: '`slug` must start with `/`.',
+        details: { slug }
+      });
+      return { warnings };
+    }
+
+    const shortRaw = typeof (fm as any)['auto-link-short-note'] === 'string'
+      ? (fm as any)['auto-link-short-note'].trim()
+      : '';
+    const shortNote = shortRaw ? shortRaw : undefined;
+
+    const iconRaw = typeof (fm as any)['auto-link-icon'] === 'string'
+      ? (fm as any)['auto-link-icon'].trim()
+      : '';
+    const icon = iconRaw ? iconRaw : undefined;
+
+    const entry: IndexRawEntry = {
+      id,
+      slug,
+      terms,
+      linkify: true,
+      icon,
+      shortNote,
+      sourcePath: file.path
+    };
+
+    return { entry, warnings };
+  } catch (err: any) {
+    warnings.push({
+      path: file.path,
+      code: 'INVALID_TYPE',
+      message: 'Failed to parse frontmatter.',
+      details: { error: String(err?.message ?? err) }
+    });
+    return { warnings };
+  }
+}
+
 export function parseFrontmatter(files: RawDocFile[]): FrontmatterParseResult {
   const entries: IndexRawEntry[] = [];
   const warnings: FrontmatterWarning[] = [];
 
   for (const file of files) {
-    if (!isSupportedExt(file.path, file.ext)) {
-      warnings.push({
-        path: file.path,
-        code: 'UNSUPPORTED_EXT',
-        message: 'Unsupported extension (only .md/.mdx are processed).'
-      });
-      continue;
-    }
-
-    try {
-      const { data } = matter(file.content ?? '');
-      const res = FM.safeParse(data ?? {});
-      if (!res.success) {
-        warnings.push({
-          path: file.path,
-          code: 'INVALID_TYPE',
-          message: 'Frontmatter has invalid shape.',
-          details: { issues: res.error.issues.map(i => ({ path: i.path, message: i.message })) }
-        });
-        continue;
-      }
-
-      const fm = res.data;
-
-      const linkify = fm.linkify ?? true;
-      if (!linkify) {
-        warnings.push({
-          path: file.path,
-          code: 'LINKIFY_FALSE',
-          message: '`linkify:false` – skipped from index.'
-        });
-        continue;
-      }
-
-      const hasAutoLinkField = Object.prototype.hasOwnProperty.call(fm, 'auto-link');
-      const autoLinkRaw = (fm as any)['auto-link'];
-
-      if (!hasAutoLinkField || typeof autoLinkRaw === 'undefined') {
-        continue;
-      }
-
-      if (!Array.isArray(autoLinkRaw)) {
-        warnings.push({
-          path: file.path,
-          code: 'INVALID_TYPE',
-          message: '`auto-link` must be an array of strings.'
-        });
-        continue;
-      }
-
-      const terms = normalizeAutoLinkTerms(autoLinkRaw);
-      if (terms.length === 0) {
-        warnings.push({
-          path: file.path,
-          code: 'EMPTY_AUTO_LINK',
-          message: '`auto-link` must include at least one non-empty string.'
-        });
-        continue;
-      }
-
-      const id = (fm.id ?? '').trim();
-      if (!id) {
-        warnings.push({
-          path: file.path,
-          code: 'EMPTY_ID',
-          message: 'Missing required `id`.'
-        });
-        continue;
-      }
-
-      const slug = (fm.slug ?? '').trim();
-      if (!slug) {
-        warnings.push({
-          path: file.path,
-          code: 'EMPTY_SLUG',
-          message: 'Missing required `slug`.'
-        });
-        continue;
-      }
-      if (!slug.startsWith('/')) {
-        warnings.push({
-          path: file.path,
-          code: 'INVALID_TYPE',
-          message: '`slug` must start with `/`.',
-          details: { slug }
-        });
-        continue;
-      }
-
-      const shortRaw = typeof (fm as any)['auto-link-short-note'] === 'string'
-        ? (fm as any)['auto-link-short-note'].trim()
-        : '';
-      const shortNote = shortRaw ? shortRaw : undefined;
-
-      const iconRaw = typeof (fm as any)['auto-link-icon'] === 'string'
-        ? (fm as any)['auto-link-icon'].trim()
-        : '';
-      const icon = iconRaw ? iconRaw : undefined;
-
-      entries.push({
-        id,
-        slug,
-        terms,
-        linkify: true,
-        icon,
-        shortNote,
-        sourcePath: file.path
-      });
-    } catch (err: any) {
-      warnings.push({
-        path: file.path,
-        code: 'INVALID_TYPE',
-        message: 'Failed to parse frontmatter.',
-        details: { error: String(err?.message ?? err) }
-      });
-      continue;
-    }
+    const { entry, warnings: fileWarnings } = parseFrontmatterFile(file);
+    if (entry) entries.push(entry);
+    if (fileWarnings.length > 0) warnings.push(...fileWarnings);
   }
 
   return { entries, warnings };

--- a/packages/docusaurus-plugin-linkify-med/src/fsIndexProvider.ts
+++ b/packages/docusaurus-plugin-linkify-med/src/fsIndexProvider.ts
@@ -1,5 +1,7 @@
-import { scanMdFiles } from './node/fsScan.js';
-import { loadIndexFromFiles } from './frontmatterAdapter.js';
+import { readFileSync } from 'node:fs';
+import { scanMdFileStats } from './node/fsScan.js';
+import { parseFrontmatterFile } from './frontmatter.js';
+import type { IndexRawEntry } from './types.js';
 
 export interface FsIndexProviderOptions {
   roots: string[]; // absolute directories to scan
@@ -27,22 +29,103 @@ export interface IndexProvider {
  * Create a remark-linkify-med IndexProvider by scanning the file system
  * for MD/MDX files and parsing their frontmatter.
  */
-export function createFsIndexProvider(opts: FsIndexProviderOptions): IndexProvider {
-  const files = scanMdFiles({ roots: opts.roots });
-  const { entries } = loadIndexFromFiles(files);
+type CacheEntry = {
+  mtimeMs: number;
+  entry?: IndexRawEntry;
+};
 
+function entriesEqual(a?: IndexRawEntry, b?: IndexRawEntry): boolean {
+  if (!a && !b) return true;
+  if (!a || !b) return false;
+  if (a.id !== b.id) return false;
+  if (a.slug !== b.slug) return false;
+  if (a.icon !== b.icon) return false;
+  if (a.sourcePath !== b.sourcePath) return false;
+  if (a.terms.length !== b.terms.length) return false;
+  for (let i = 0; i < a.terms.length; i += 1) {
+    if (a.terms[i] !== b.terms[i]) return false;
+  }
+  return true;
+}
+
+export function createFsIndexProvider(opts: FsIndexProviderOptions): IndexProvider {
+  const roots = opts.roots;
   const prefix = opts.slugPrefix ?? '';
-  const targets: TargetInfo[] = entries.map(e => ({
-    id: e.id,
-    slug: `${prefix}${e.slug}`,
-    icon: e.icon,
-    sourcePath: e.sourcePath,
-    terms: e.terms,
-  }));
+
+  const cache = new Map<string, CacheEntry>();
+  let targetsCache: TargetInfo[] | null = null;
+
+  function rebuildTargets() {
+    const next: TargetInfo[] = [];
+    for (const value of cache.values()) {
+      const entry = value.entry;
+      if (!entry) continue;
+      next.push({
+        id: entry.id,
+        slug: `${prefix}${entry.slug}`,
+        icon: entry.icon,
+        sourcePath: entry.sourcePath,
+        terms: entry.terms,
+      });
+    }
+    next.sort((a, b) => a.id.localeCompare(b.id));
+    targetsCache = next;
+  }
+
+  function syncCache(): boolean {
+    const stats = scanMdFileStats({ roots });
+    const statsMap = new Map(stats.map(item => [item.path, item]));
+
+    let changed = false;
+
+    for (const existing of Array.from(cache.keys())) {
+      if (!statsMap.has(existing)) {
+        const prev = cache.get(existing);
+        if (prev?.entry) changed = true;
+        cache.delete(existing);
+      }
+    }
+
+    for (const stat of stats) {
+      const previous = cache.get(stat.path);
+      if (previous && previous.mtimeMs === stat.mtimeMs) {
+        continue;
+      }
+
+      let entry: IndexRawEntry | undefined;
+      try {
+        const content = readFileSync(stat.path, 'utf8');
+        ({ entry } = parseFrontmatterFile({
+          path: stat.path,
+          content,
+          ext: stat.ext,
+        }));
+      } catch {
+        if (previous?.entry) changed = true;
+        cache.delete(stat.path);
+        continue;
+      }
+
+      if (!entriesEqual(previous?.entry, entry)) {
+        changed = true;
+      }
+
+      cache.set(stat.path, {
+        mtimeMs: stat.mtimeMs,
+        entry,
+      });
+    }
+
+    return changed;
+  }
 
   return {
     getAllTargets() {
-      return targets;
+      const cacheChanged = syncCache();
+      if (cacheChanged || targetsCache === null) {
+        rebuildTargets();
+      }
+      return targetsCache ?? [];
     },
     getCurrentFilePath(file) {
       return file.path || '';

--- a/packages/docusaurus-plugin-linkify-med/src/index.ts
+++ b/packages/docusaurus-plugin-linkify-med/src/index.ts
@@ -1,13 +1,18 @@
+import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { Plugin } from '@docusaurus/types';
 import type { LoadContext, PluginContentLoadedActions } from '@docusaurus/types';
 import { validateOptions, type PluginOptions, type NormalizedOptions } from './options.js';
-import { scanMdFiles } from './node/fsScan.js';
-import { buildArtifacts } from './node/buildPipeline.js';
+import { scanMdFileStats } from './node/fsScan.js';
+import { parseFrontmatterFile } from './frontmatter.js';
 import type { IndexRawEntry } from './types.js';
-import type { NoteModule } from './codegen/notesEmitter.js';
-import type { RegistryModule } from './codegen/registryEmitter.js';
+import {
+  emitShortNoteModule,
+  type NoteModule,
+  type CompileMdx,
+} from './codegen/notesEmitter.js';
+import { emitRegistry, type RegistryModule } from './codegen/registryEmitter.js';
 import { emitTooltipComponentsModule } from './codegen/tooltipComponentsEmitter.js';
 import { PLUGIN_NAME } from './pluginName.js';
 import { createTooltipMdxCompiler } from './node/tooltipMdxCompiler.js';
@@ -32,19 +37,101 @@ type Content = {
 const moduleDir = dirname(fileURLToPath(import.meta.url));
 const pluginName = PLUGIN_NAME;
 
-export default function linkifyMedPlugin(_context: LoadContext, optsIn?: PluginOptions): Plugin<Content> {
+type CachedFrontmatter = {
+  mtimeMs: number;
+  entry?: IndexRawEntry;
+  noteModule?: NoteModule | null;
+};
+
+export default function linkifyMedPlugin(
+  _context: LoadContext,
+  optsIn?: PluginOptions
+): Plugin<Content> {
   const { options: normOpts } = validateOptions(optsIn);
+  const cache = new Map<string, CachedFrontmatter>();
+  const roots = [_context.siteDir];
+
+  let compileMdxCache: CompileMdx | undefined;
+  let compileMdxPromise: Promise<CompileMdx> | null = null;
+
+  async function ensureCompileMdx(): Promise<CompileMdx> {
+    if (compileMdxCache) return compileMdxCache;
+    if (!compileMdxPromise) {
+      compileMdxPromise = createTooltipMdxCompiler(_context);
+    }
+    compileMdxCache = await compileMdxPromise;
+    return compileMdxCache;
+  }
 
   return {
     name: pluginName,
 
+    getPathsToWatch() {
+      return ['**/*.md', '**/*.mdx'];
+    },
+
     async loadContent() {
-      const roots = [_context.siteDir];
-      const files = scanMdFiles({ roots });
-      const compileMdx = await createTooltipMdxCompiler(_context);
-      const { entries, notes, registry } = await buildArtifacts(files, {
-        compileMdx,
-      });
+      const stats = scanMdFileStats({ roots });
+      const statsMap = new Map(stats.map(item => [item.path, item]));
+
+      for (const existing of Array.from(cache.keys())) {
+        if (!statsMap.has(existing)) {
+          cache.delete(existing);
+        }
+      }
+
+      for (const stat of stats) {
+        const previous = cache.get(stat.path);
+        if (previous && previous.mtimeMs === stat.mtimeMs) {
+          continue;
+        }
+
+        let entry: IndexRawEntry | undefined;
+        try {
+          const content = readFileSync(stat.path, 'utf8');
+          ({ entry } = parseFrontmatterFile({
+            path: stat.path,
+            content,
+            ext: stat.ext,
+          }));
+        } catch {
+          cache.delete(stat.path);
+          continue;
+        }
+
+        let noteModule: NoteModule | null = null;
+        if (entry?.shortNote) {
+          if (
+            previous?.entry &&
+            previous.entry.id === entry.id &&
+            previous.entry.shortNote === entry.shortNote &&
+            previous.noteModule
+          ) {
+            noteModule = previous.noteModule;
+          } else {
+            const compiler = await ensureCompileMdx();
+            noteModule = (await emitShortNoteModule(entry.id, entry.shortNote, compiler)) ?? null;
+          }
+        }
+
+        cache.set(stat.path, {
+          mtimeMs: stat.mtimeMs,
+          entry,
+          noteModule,
+        });
+      }
+
+      const entries = Array.from(cache.values())
+        .map(item => item.entry)
+        .filter((e): e is IndexRawEntry => Boolean(e))
+        .sort((a, b) => a.id.localeCompare(b.id));
+
+      const notes = Array.from(cache.values())
+        .map(item => item.noteModule)
+        .filter((mod): mod is NoteModule => Boolean(mod))
+        .sort((a, b) => a.filename.localeCompare(b.filename));
+
+      const registry = emitRegistry(entries, notes);
 
       return {
         entries,

--- a/packages/docusaurus-plugin-linkify-med/src/theme/runtime/LinkifyShortNote.tsx
+++ b/packages/docusaurus-plugin-linkify-med/src/theme/runtime/LinkifyShortNote.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useMDXComponents } from '@mdx-js/react';
 import { LinkifyRegistryContext } from './context.js';
 
 export interface LinkifyShortNoteProps {
@@ -9,6 +10,7 @@ export interface LinkifyShortNoteProps {
 
 export default function LinkifyShortNote({ tipKey, fallback = null, components }: LinkifyShortNoteProps) {
   const registry = React.useContext(LinkifyRegistryContext);
+  const mdxComponents = useMDXComponents();
   if (!tipKey) {
     return fallback ?? null;
   }
@@ -19,5 +21,9 @@ export default function LinkifyShortNote({ tipKey, fallback = null, components }
     return fallback ?? null;
   }
 
-  return <Short components={components} />;
+  const mergedComponents = components
+    ? { ...mdxComponents, ...components }
+    : mdxComponents;
+
+  return <Short components={mergedComponents} />;
 }

--- a/packages/docusaurus-plugin-linkify-med/src/types.ts
+++ b/packages/docusaurus-plugin-linkify-med/src/types.ts
@@ -32,6 +32,11 @@ export interface FrontmatterWarning {
   details?: Record<string, unknown>;
 }
 
+export interface FrontmatterParseFileResult {
+  entry?: IndexRawEntry;
+  warnings: FrontmatterWarning[];
+}
+
 export interface FrontmatterParseResult {
   entries: IndexRawEntry[];
   warnings: FrontmatterWarning[];

--- a/packages/docusaurus-plugin-linkify-med/tests/theme.root.test.tsx
+++ b/packages/docusaurus-plugin-linkify-med/tests/theme.root.test.tsx
@@ -36,6 +36,7 @@ vi.mock('@generated/docusaurus-plugin-linkify-med/default/registry', () => ({
         const Tip = components?.DrugTip ?? (() => null);
         return (
           <div data-testid="shortnote">
+            Short note!
             <Tip note="From provider" />
           </div>
         );


### PR DESCRIPTION
## Summary
- cache parsed frontmatter and compiled short notes so only changed markdown files are reparsed during dev reloads
- add reusable single-file frontmatter parser and filesystem stat scanning helpers used by the plugin cache
- wire LinkifyShortNote through the MDX components context and update the theme root test mock to cover the expected note text

## Testing
- pnpm -r --filter './packages/**' run test --

------
https://chatgpt.com/codex/tasks/task_e_68ca643693648331ae6db4a556aed933