### PR TITLE
Align smart link styling with site defaults

### DIFF
--- a/packages/docusaurus-plugin-linkify-med/src/theme/styles.css
+++ b/packages/docusaurus-plugin-linkify-med/src/theme/styles.css
@@ -1,7 +1,6 @@
 .lm-smartlink {
   display: inline-flex;
   align-items: center;
-  text-decoration: underline;
   gap: var(
     --lm-smartlink-gap,
     calc(var(--ifm-spacing-horizontal, 1.5rem) / 6)


### PR DESCRIPTION
## Summary
- remove the forced underline from smart links so they inherit the site's default link styling

## Testing
- pnpm test *(fails: theme Root provider > exposes LinkifyShortNote through the MDX provider, also failing on main)*

------
https://chatgpt.com/codex/tasks/task_e_68ca6d321a8c83318223e8113e216728