### PR TITLE
Add GitHub Pages deployment for example site

### DIFF
--- a/.github/workflows/deploy-example-site.yml
+++ b/.github/workflows/deploy-example-site.yml
@@ -1,0 +1,66 @@
+name: Deploy example site
+
+on:
+  push:
+    branches:
+      - main
+      - work
+  workflow_dispatch:
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+          run_install: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm -r --filter './packages/**' run build
+
+      - name: Build example site
+        run: pnpm site:build
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: examples/site/build
+
+  deploy:
+    runs-on: ubuntu-latest
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/examples/site/docusaurus.config.ts
+++ b/examples/site/docusaurus.config.ts
@@ -6,6 +6,30 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+const [repoOwner = 'smartlinkmed', repoName = 'docusaurus-plugin-smartlinker'] =
+  process.env.GITHUB_REPOSITORY?.split('/') ?? [];
+
+const isGithubActions = process.env.GITHUB_ACTIONS === 'true';
+
+const siteUrl = process.env.SITE_URL ?? (isGithubActions ? `https://${repoOwner}.github.io` : 'http://localhost:3000');
+
+const ensureSlashes = (value: string) => {
+  const withLeading = value.startsWith('/') ? value : `/${value}`;
+  return withLeading.endsWith('/') ? withLeading : `${withLeading}/`;
+};
+
+const normalizedBaseUrl = (() => {
+  if (process.env.SITE_BASE_URL) {
+    return ensureSlashes(process.env.SITE_BASE_URL);
+  }
+
+  if (isGithubActions && repoName) {
+    return ensureSlashes(`/${repoName}`);
+  }
+
+  return '/';
+})();
+
 const linkifyIndex = createFsIndexProvider({
   roots: [join(__dirname, 'docs')],
   slugPrefix: '/docs',
@@ -14,10 +38,10 @@ const linkifyIndex = createFsIndexProvider({
 const config: Config = {
   title: 'Smartlinker Example',
   favicon: 'img/favicon.ico',
-  url: 'https://example.com',
-  baseUrl: '/',
-  organizationName: 'smartlinker',
-  projectName: 'example',
+  url: siteUrl,
+  baseUrl: normalizedBaseUrl,
+  organizationName: repoOwner,
+  projectName: repoName,
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   i18n: {


### PR DESCRIPTION
## Summary
- derive the example site's url and baseUrl from GitHub environment variables so GitHub Pages builds use the correct prefix
- add a GitHub Actions workflow that builds the packages and example site and deploys the static output to GitHub Pages

## Testing
- pnpm -r --filter './packages/**' run build
- pnpm -r --filter './packages/**' run test
- pnpm site:build

------
https://chatgpt.com/codex/tasks/task_e_68ca74f50d6083318b4930f8259e3294