### PR TITLE
Fix homepage redirect for GitHub Pages base URL

### DIFF
--- a/examples/site/src/pages/index.mdx
+++ b/examples/site/src/pages/index.mdx
@@ -4,7 +4,17 @@ title: Home
 
 import {Redirect} from '@docusaurus/router';
 import Link from '@docusaurus/Link';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 
-<Redirect to="/docs/overview" />
+export default function Home() {
+  const overviewUrl = useBaseUrl('/docs/overview');
 
-If you are not redirected automatically, open the <Link to="/docs/overview">example overview</Link> to explore the live demos.
+  return (
+    <>
+      <Redirect to={overviewUrl} />
+      <p>
+        If you are not redirected automatically, open the <Link to={overviewUrl}>example overview</Link> to explore the live demos.
+      </p>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- compute the docs overview redirect target with `useBaseUrl` and render the home page via a component
- ensure the homepage link and redirect honor the repository base path on GitHub Pages

## Testing
- GITHUB_ACTIONS=true GITHUB_REPOSITORY=uli-z/docusaurus-plugin-smartlinker npm run site:build

------
https://chatgpt.com/codex/tasks/task_e_68caa3021dd08331ba2ddb2e9724c92e