### PR TITLE
docs(example): demonstrate styling SmartLinks with CSS

### DIFF
--- a/examples/site/docs/demo.mdx
+++ b/examples/site/docs/demo.mdx
@@ -87,6 +87,65 @@ smartlink-short-note: |
 - Longest match wins; non-overlapping, left-to-right; all occurrences.
 - Skips code blocks, inline code, links, images, and H1–H3.
 
+## Style SmartLinks with CSS
+
+SmartLinks expose dedicated class names (`.lm-smartlink`, `.lm-smartlink__icon`, `.lm-tooltip`, …) and CSS custom properties, so you can restyle links and tooltips just like any other element.
+
+1. Load your stylesheet through the classic preset:
+
+   ```ts title="docusaurus.config.ts"
+   theme: {
+     customCss: join(__dirname, 'src/css/custom.css'),
+   },
+   ```
+
+2. Override the classes or tweak the `--lm-*` variables in `src/css/custom.css`:
+
+   ```css title="src/css/custom.css"
+   :root {
+     --lm-tooltip-bg: #0f172a;
+     --lm-tooltip-color: #f8fafc;
+     --lm-tooltip-radius: 0.75rem;
+     --lm-tooltip-shadow: 0 18px 38px rgba(15, 23, 42, 0.35);
+     --lm-tooltip-padding: 0.85rem 1rem;
+   }
+
+   html[data-theme='dark'] {
+     --lm-tooltip-bg: #1f2937;
+     --lm-tooltip-shadow: 0 18px 38px rgba(15, 23, 42, 0.55);
+   }
+
+   .markdown .lm-smartlink {
+     --lm-smartlink-gap: 0.35rem;
+     border-bottom: 1px dashed var(--ifm-color-primary);
+     border-radius: 0.25rem;
+     padding-inline: 0.15rem;
+     transition: background 150ms ease, color 150ms ease;
+   }
+
+   .markdown .lm-smartlink:hover {
+     background: rgba(59, 130, 246, 0.12);
+   }
+
+   html[data-theme='dark'] .markdown .lm-smartlink:hover {
+     background: rgba(96, 165, 250, 0.25);
+   }
+
+   .markdown .lm-smartlink__iconwrap {
+     --lm-smartlink-icon-gap: 0.25rem;
+   }
+
+   .markdown .lm-smartlink__icon {
+     filter: drop-shadow(0 2px 4px rgba(59, 130, 246, 0.35));
+   }
+
+   .markdown .lm-tooltip-content {
+     line-height: 1.5;
+   }
+   ```
+
+The dashed underline and tooltip colors you see on this page come from these overrides.
+
 ## Opt out
 
 ```mdx

--- a/examples/site/docs/demo.mdx
+++ b/examples/site/docs/demo.mdx
@@ -103,16 +103,17 @@ SmartLinks expose dedicated class names (`.lm-smartlink`, `.lm-smartlink__icon`,
 
    ```css title="src/css/custom.css"
    :root {
-     --lm-tooltip-bg: #0f172a;
-     --lm-tooltip-color: #f8fafc;
-     --lm-tooltip-radius: 0.75rem;
-     --lm-tooltip-shadow: 0 18px 38px rgba(15, 23, 42, 0.35);
-     --lm-tooltip-padding: 0.85rem 1rem;
+    --lm-tooltip-bg: rgba(34, 197, 94, 0.9);
+    --lm-tooltip-color: #022c22;
+    --lm-tooltip-radius: 0.75rem;
+    --lm-tooltip-shadow: 0 18px 38px rgba(34, 197, 94, 0.45);
+    --lm-tooltip-padding: 0.85rem 1rem;
    }
 
    html[data-theme='dark'] {
-     --lm-tooltip-bg: #1f2937;
-     --lm-tooltip-shadow: 0 18px 38px rgba(15, 23, 42, 0.55);
+    --lm-tooltip-bg: rgba(22, 163, 74, 0.9);
+    --lm-tooltip-color: #ecfdf5;
+    --lm-tooltip-shadow: 0 18px 38px rgba(22, 163, 74, 0.55);
    }
 
    .markdown .lm-smartlink {
@@ -144,7 +145,7 @@ SmartLinks expose dedicated class names (`.lm-smartlink`, `.lm-smartlink__icon`,
    }
    ```
 
-The dashed underline and tooltip colors you see on this page come from these overrides.
+The dashed underline and tooltip colors you see on this page come from these overrides. Setting `--lm-tooltip-bg` to a `rgba(..., 0.9)` value, for example, gives the tooltip a softly transparent, greenish glow while preserving text readability. Pair it with `--lm-tooltip-color` to balance contrast for your tinted background.
 
 ## Opt out
 

--- a/examples/site/docusaurus.config.ts
+++ b/examples/site/docusaurus.config.ts
@@ -61,7 +61,9 @@ const config: Config = {
         pages: {
           remarkPlugins: [[remarkLinkifyMed, { index: linkifyIndex }]],
         },
-        theme: {},
+        theme: {
+          customCss: join(__dirname, 'src/css/custom.css'),
+        },
       },
     ],
   ],

--- a/examples/site/src/css/custom.css
+++ b/examples/site/src/css/custom.css
@@ -1,0 +1,40 @@
+:root {
+  --lm-tooltip-bg: #0f172a;
+  --lm-tooltip-color: #f8fafc;
+  --lm-tooltip-radius: 0.75rem;
+  --lm-tooltip-shadow: 0 18px 38px rgba(15, 23, 42, 0.35);
+  --lm-tooltip-padding: 0.85rem 1rem;
+}
+
+html[data-theme='dark'] {
+  --lm-tooltip-bg: #1f2937;
+  --lm-tooltip-shadow: 0 18px 38px rgba(15, 23, 42, 0.55);
+}
+
+.markdown .lm-smartlink {
+  --lm-smartlink-gap: 0.35rem;
+  border-bottom: 1px dashed var(--ifm-color-primary);
+  border-radius: 0.25rem;
+  padding-inline: 0.15rem;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.markdown .lm-smartlink:hover {
+  background: rgba(59, 130, 246, 0.12);
+}
+
+html[data-theme='dark'] .markdown .lm-smartlink:hover {
+  background: rgba(96, 165, 250, 0.25);
+}
+
+.markdown .lm-smartlink__iconwrap {
+  --lm-smartlink-icon-gap: 0.25rem;
+}
+
+.markdown .lm-smartlink__icon {
+  filter: drop-shadow(0 2px 4px rgba(59, 130, 246, 0.35));
+}
+
+.markdown .lm-tooltip-content {
+  line-height: 1.5;
+}

--- a/examples/site/src/css/custom.css
+++ b/examples/site/src/css/custom.css
@@ -1,14 +1,15 @@
 :root {
-  --lm-tooltip-bg: #0f172a;
-  --lm-tooltip-color: #f8fafc;
+  --lm-tooltip-bg: rgba(34, 197, 94, 0.9);
+  --lm-tooltip-color: #022c22;
   --lm-tooltip-radius: 0.75rem;
-  --lm-tooltip-shadow: 0 18px 38px rgba(15, 23, 42, 0.35);
+  --lm-tooltip-shadow: 0 18px 38px rgba(34, 197, 94, 0.45);
   --lm-tooltip-padding: 0.85rem 1rem;
 }
 
 html[data-theme='dark'] {
-  --lm-tooltip-bg: #1f2937;
-  --lm-tooltip-shadow: 0 18px 38px rgba(15, 23, 42, 0.55);
+  --lm-tooltip-bg: rgba(22, 163, 74, 0.9);
+  --lm-tooltip-color: #ecfdf5;
+  --lm-tooltip-shadow: 0 18px 38px rgba(22, 163, 74, 0.55);
 }
 
 .markdown .lm-smartlink {


### PR DESCRIPTION
## Summary
- load a custom stylesheet in the example site and override SmartLink link/tooltip styles
- document how to adjust SmartLink styles with CSS in the live demo page

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68cbedc7ec308331b23aad6542c68d37