### PR TITLE
feat: split smartlink text and icon elements

### DIFF
--- a/examples/site/docs/demo.mdx
+++ b/examples/site/docs/demo.mdx
@@ -103,28 +103,32 @@ SmartLinks expose dedicated class names (`.lm-smartlink`, `.lm-smartlink__anchor
 
    ```css title="src/css/custom.css"
    :root {
-    --lm-tooltip-bg: rgba(34, 197, 94, 0.9);
-    --lm-tooltip-color: #022c22;
+    --lm-tooltip-bg: rgba(107, 114, 128, 0.9);
+    --lm-tooltip-color: #111827;
     --lm-tooltip-radius: 0.75rem;
-    --lm-tooltip-shadow: 0 18px 38px rgba(34, 197, 94, 0.45);
+    --lm-tooltip-shadow: 0 18px 38px rgba(107, 114, 128, 0.45);
     --lm-tooltip-padding: 0.85rem 1rem;
    }
 
    html[data-theme='dark'] {
-    --lm-tooltip-bg: rgba(22, 163, 74, 0.9);
-    --lm-tooltip-color: #ecfdf5;
-    --lm-tooltip-shadow: 0 18px 38px rgba(22, 163, 74, 0.55);
+    --lm-tooltip-bg: rgba(148, 163, 184, 0.9);
+    --lm-tooltip-color: #f9fafb;
+    --lm-tooltip-shadow: 0 18px 38px rgba(148, 163, 184, 0.55);
    }
 
    .markdown .lm-smartlink {
      --lm-smartlink-gap: 0.35rem;
-     border-bottom: 1px dashed var(--ifm-color-primary);
-     border-radius: 0.25rem;
-     padding-inline: 0.15rem;
+     border-radius: 0.35rem;
+     padding: 0.1rem 0.3rem;
+     background: rgba(107, 114, 128, 0.08);
      transition: background 150ms ease, color 150ms ease;
    }
 
    .markdown .lm-smartlink__anchor {
+     text-decoration: none;
+   }
+
+   .markdown .lm-smartlink:hover .lm-smartlink__anchor {
      text-decoration: underline;
    }
 
@@ -134,11 +138,15 @@ SmartLinks expose dedicated class names (`.lm-smartlink`, `.lm-smartlink__anchor
    }
 
    .markdown .lm-smartlink:hover {
-     background: rgba(59, 130, 246, 0.12);
+     background: rgba(107, 114, 128, 0.14);
+   }
+
+   html[data-theme='dark'] .markdown .lm-smartlink {
+     background: rgba(148, 163, 184, 0.12);
    }
 
    html[data-theme='dark'] .markdown .lm-smartlink:hover {
-     background: rgba(96, 165, 250, 0.25);
+     background: rgba(148, 163, 184, 0.18);
    }
 
    .markdown .lm-smartlink__iconwrap {
@@ -146,7 +154,7 @@ SmartLinks expose dedicated class names (`.lm-smartlink`, `.lm-smartlink__anchor
    }
 
    .markdown .lm-smartlink__icon {
-     filter: drop-shadow(0 2px 4px rgba(59, 130, 246, 0.35));
+     filter: drop-shadow(0 2px 4px rgba(107, 114, 128, 0.25));
    }
 
    .markdown .lm-tooltip-content {
@@ -154,7 +162,7 @@ SmartLinks expose dedicated class names (`.lm-smartlink`, `.lm-smartlink__anchor
    }
    ```
 
-The dashed underline and tooltip colors you see on this page come from these overrides. Setting `--lm-tooltip-bg` to a `rgba(..., 0.9)` value, for example, gives the tooltip a softly transparent, greenish glow while preserving text readability. Pair it with `--lm-tooltip-color` to balance contrast for your tinted background.
+The muted background, neutral tooltip, and hover underline you see on this page come from these overrides. Setting `--lm-tooltip-bg` to a `rgba(..., 0.9)` value keeps the gentle transparency while shifting to a balanced gray. Pair it with `--lm-tooltip-color` to maintain contrast for your tinted background. Only the text label is underlined on hover so the trailing icon stays neutral.
 
 ## Opt out
 

--- a/examples/site/docs/demo.mdx
+++ b/examples/site/docs/demo.mdx
@@ -89,7 +89,7 @@ smartlink-short-note: |
 
 ## Style SmartLinks with CSS
 
-SmartLinks expose dedicated class names (`.lm-smartlink`, `.lm-smartlink__icon`, `.lm-tooltip`, …) and CSS custom properties, so you can restyle links and tooltips just like any other element.
+SmartLinks expose dedicated class names (`.lm-smartlink`, `.lm-smartlink__anchor`, `.lm-smartlink__iconlink`, `.lm-smartlink__icon`, `.lm-tooltip`, …) and CSS custom properties, so you can restyle links and tooltips just like any other element. The text and trailing icon are now separate elements, so emphasis (for example `_Amoxi_`) can style the label without affecting the emoji or SVG.
 
 1. Load your stylesheet through the classic preset:
 
@@ -122,6 +122,15 @@ SmartLinks expose dedicated class names (`.lm-smartlink`, `.lm-smartlink__icon`,
      border-radius: 0.25rem;
      padding-inline: 0.15rem;
      transition: background 150ms ease, color 150ms ease;
+   }
+
+   .markdown .lm-smartlink__anchor {
+     text-decoration: underline;
+   }
+
+   .markdown .lm-smartlink__iconlink {
+     font-style: normal;
+     text-decoration: none;
    }
 
    .markdown .lm-smartlink:hover {

--- a/examples/site/src/css/custom.css
+++ b/examples/site/src/css/custom.css
@@ -1,39 +1,57 @@
 :root {
-  --lm-tooltip-bg: rgba(34, 197, 94, 0.9);
-  --lm-tooltip-color: #022c22;
+  --lm-tooltip-bg: rgba(107, 114, 128, 0.9);
+  --lm-tooltip-color: #111827;
   --lm-tooltip-radius: 0.75rem;
-  --lm-tooltip-shadow: 0 18px 38px rgba(34, 197, 94, 0.45);
+  --lm-tooltip-shadow: 0 18px 38px rgba(107, 114, 128, 0.45);
   --lm-tooltip-padding: 0.85rem 1rem;
 }
 
 html[data-theme='dark'] {
-  --lm-tooltip-bg: rgba(22, 163, 74, 0.9);
-  --lm-tooltip-color: #ecfdf5;
-  --lm-tooltip-shadow: 0 18px 38px rgba(22, 163, 74, 0.55);
+  --lm-tooltip-bg: rgba(148, 163, 184, 0.9);
+  --lm-tooltip-color: #f9fafb;
+  --lm-tooltip-shadow: 0 18px 38px rgba(148, 163, 184, 0.55);
 }
 
 .markdown .lm-smartlink {
   --lm-smartlink-gap: 0.35rem;
-  border-bottom: 1px dashed var(--ifm-color-primary);
-  border-radius: 0.25rem;
-  padding-inline: 0.15rem;
+  border-radius: 0.35rem;
+  padding: 0.1rem 0.3rem;
+  background: rgba(107, 114, 128, 0.08);
   transition: background 150ms ease, color 150ms ease;
 }
 
 .markdown .lm-smartlink:hover {
-  background: rgba(59, 130, 246, 0.12);
+  background: rgba(107, 114, 128, 0.14);
+}
+
+html[data-theme='dark'] .markdown .lm-smartlink {
+  background: rgba(148, 163, 184, 0.12);
 }
 
 html[data-theme='dark'] .markdown .lm-smartlink:hover {
-  background: rgba(96, 165, 250, 0.25);
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.markdown .lm-smartlink__anchor {
+  text-decoration: none;
+  color: inherit;
+}
+
+.markdown .lm-smartlink:hover .lm-smartlink__anchor {
+  text-decoration: underline;
 }
 
 .markdown .lm-smartlink__iconwrap {
   --lm-smartlink-icon-gap: 0.25rem;
 }
 
+.markdown .lm-smartlink__iconlink {
+  font-style: normal;
+  text-decoration: none;
+}
+
 .markdown .lm-smartlink__icon {
-  filter: drop-shadow(0 2px 4px rgba(59, 130, 246, 0.35));
+  filter: drop-shadow(0 2px 4px rgba(107, 114, 128, 0.25));
 }
 
 .markdown .lm-tooltip-content {

--- a/packages/docusaurus-plugin-smartlinker/CHANGELOG.md
+++ b/packages/docusaurus-plugin-smartlinker/CHANGELOG.md
@@ -6,3 +6,4 @@
 - wire the plugin’s contexts through `@theme/Root` and register `<SmartLink>` globally via `MDXProvider`
 - expose tooltip markup and icon data at SSR by adding `data-tipkey` attributes and a hidden `lm-tooltip-content` fallback
 - load `styles.css` through `getClientModules()` so consumers do not need manual stylesheet imports
+- render SmartLink text and icon as separate anchors so emphasis styling can target each element independently

--- a/packages/docusaurus-plugin-smartlinker/src/theme/styles.css
+++ b/packages/docusaurus-plugin-smartlinker/src/theme/styles.css
@@ -7,12 +7,28 @@
   );
 }
 
+.lm-smartlink__anchor,
+.lm-smartlink__iconlink {
+  display: inline-flex;
+  align-items: center;
+}
+
+.lm-smartlink__anchor {
+  color: inherit;
+  text-decoration: inherit;
+}
+
+.lm-smartlink__iconlink {
+  text-decoration: none;
+}
+
 .lm-smartlink__iconwrap {
   display: inline-flex;
   margin-left: var(
     --lm-smartlink-icon-gap,
     calc(var(--ifm-spacing-horizontal, 1.5rem) / 10)
   );
+  font-style: normal;
 }
 
 .lm-smartlink__icon {

--- a/packages/docusaurus-plugin-smartlinker/tests/theme.root.test.tsx
+++ b/packages/docusaurus-plugin-smartlinker/tests/theme.root.test.tsx
@@ -65,7 +65,7 @@ describe('theme Root provider', () => {
 
     expect(usePluginDataMock).toHaveBeenCalledWith(PLUGIN_NAME);
 
-    const link = screen.getByRole('link', { name: /Amoxi/ });
+    const link = screen.getByRole('link', { name: /^Amoxi$/ });
     expect(link).toHaveAttribute('href', '/docs/amoxicillin');
     expect(link).toHaveAttribute('data-tipkey', 'amoxicillin');
 

--- a/packages/docusaurus-plugin-smartlinker/tests/theme.smartlink.test.tsx
+++ b/packages/docusaurus-plugin-smartlinker/tests/theme.smartlink.test.tsx
@@ -53,17 +53,20 @@ describe('SmartLink (theme)', () => {
       <SmartLink to="/antibiotics/amoxicillin" icon="pill" tipKey="amoxicillin">Amoxi</SmartLink>,
       { registry: { amoxicillin: { id: 'amoxicillin', slug: '/antibiotics/amoxicillin', icon: 'pill' } } }
     );
-    const a = screen.getByRole('link', { name: /Amoxi/ });
-    expect(a).toHaveAttribute('href', '/antibiotics/amoxicillin');
-    expect(a).toHaveAttribute('data-tipkey', 'amoxicillin');
+    const textLink = screen.getByRole('link', { name: /^Amoxi$/ });
+    expect(textLink).toHaveAttribute('href', '/antibiotics/amoxicillin');
+    expect(textLink).toHaveAttribute('data-tipkey', 'amoxicillin');
 
-    // The icon img should be present and logically after text in DOM order
-    const text = screen.getByText('Amoxi');
-    const imgs = a.querySelectorAll('img');
-    expect(imgs.length).toBe(1);
-    // ensure the icon node comes after the text in the anchor's children
-    const order = Array.from(a.childNodes);
-    expect(order.indexOf(text.parentElement!)).toBeLessThan(order.indexOf(imgs[0].parentElement!.parentElement!));
+    const wrapper = textLink.closest('.lm-smartlink') as HTMLElement;
+    expect(wrapper).toBeTruthy();
+
+    const iconLink = wrapper.querySelector('.lm-smartlink__iconlink') as HTMLAnchorElement;
+    expect(iconLink).toBeTruthy();
+    expect(iconLink).toHaveAttribute('href', '/antibiotics/amoxicillin');
+
+    const order = Array.from(wrapper.children);
+    expect(order.indexOf(textLink)).toBe(0);
+    expect(order.indexOf(iconLink)).toBeGreaterThan(order.indexOf(textLink));
   });
 
   it('desktop hover shows tooltip content when ShortNote exists', async () => {
@@ -71,10 +74,11 @@ describe('SmartLink (theme)', () => {
       <SmartLink to="/x" icon="pill" tipKey="amoxicillin">Amoxi</SmartLink>,
       { registry: { amoxicillin: { id: 'amoxicillin', slug: '/x', icon: 'pill', ShortNote: Note } } }
     );
-    const link = screen.getByRole('link', { name: /Amoxi/ });
+    const link = screen.getByRole('link', { name: /^Amoxi$/ });
     expect(link).toHaveAttribute('data-tipkey', 'amoxicillin');
+    const wrapper = link.closest('.lm-smartlink') as HTMLElement;
     // hover
-    await userEvent.hover(link);
+    await userEvent.hover(wrapper);
     // content should appear (Radix may render multiple nodes)
     const tips = await screen.findAllByTestId('tooltip-note');
     expect(tips.length).toBeGreaterThan(0);
@@ -94,11 +98,12 @@ describe('SmartLink (theme)', () => {
       { registry: { amoxicillin: { id: 'amoxicillin', slug: '/x', icon: 'pill', ShortNote: Note } } }
     );
 
-    const link = screen.getByRole('link', { name: /Amoxi/ });
-    const icon = link.querySelector('.lm-smartlink__icon') as HTMLElement;
+    const link = screen.getByRole('link', { name: /^Amoxi$/ });
+    const wrapper = link.closest('.lm-smartlink') as HTMLElement;
+    const iconLink = wrapper.querySelector('.lm-smartlink__iconlink') as HTMLAnchorElement;
 
     // Tap icon: tooltip shows
-    await userEvent.click(icon);
+    await userEvent.click(iconLink);
     const tips = await screen.findAllByTestId('tooltip-note');
     expect(tips.length).toBeGreaterThan(0);
 
@@ -112,8 +117,9 @@ describe('SmartLink (theme)', () => {
     setup(<SmartLink to="/x" icon="pill" tipKey="amoxicillin">Amoxi</SmartLink>, {
       registry: { amoxicillin: { id: 'amoxicillin', slug: '/x', icon: 'pill' } }
     });
-    const link = screen.getByRole('link', { name: /Amoxi/ });
-    await userEvent.hover(link);
+    const link = screen.getByRole('link', { name: /^Amoxi$/ });
+    const wrapper = link.closest('.lm-smartlink') as HTMLElement;
+    await userEvent.hover(wrapper);
     // there should be no tooltip content rendered
     const tip = screen.queryByTestId('tooltip-note');
     expect(tip).toBeNull();
@@ -143,8 +149,9 @@ describe('SmartLink (theme)', () => {
       }
     );
 
-    const link = screen.getByRole('link', { name: /Amoxi/ });
-    await userEvent.hover(link);
+    const link = screen.getByRole('link', { name: /^Amoxi$/ });
+    const wrapper = link.closest('.lm-smartlink') as HTMLElement;
+    await userEvent.hover(wrapper);
 
     const bold = await screen.findAllByText('Aminopenicillin.', { selector: 'strong' });
     expect(bold.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Summary
- render SmartLink text and trailing icon as separate anchors so the glyph is not affected by emphasis styling
- update default theme styles to keep the icon neutral and add aria metadata for the new structure
- document the markup change and adjust tests to reflect the separate elements

## Testing
- pnpm -r --filter docusaurus-plugin-smartlinker test

------
https://chatgpt.com/codex/tasks/task_e_68cc406dd14c8331b20b708aa8019f84