### PR TITLE
feat: bundle plugin and remark under single package

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,15 +23,16 @@ This monorepo hosts the Docusaurus plugin and remark helper used by the example 
 ### 1. Install the packages
 
 ```bash
-pnpm add docusaurus-plugin-smartlinker remark-linkify-med
+pnpm add github:smartlinkmed/docusaurus-plugin-smartlinker
 ```
 
-Use your preferred package manager; pnpm is shown because the example site relies on it.
+Use your preferred package manager; pnpm is shown because the example site relies on it. Installing straight from GitHub pulls
+in both the Docusaurus plugin and the remark helper from this monorepo.
 
 ### 2. Configure Docusaurus
 
 ```ts
-import remarkLinkifyMed from 'remark-linkify-med';
+import remarkLinkifyMed from 'docusaurus-plugin-smartlinker/remark';
 import { createFsIndexProvider } from 'docusaurus-plugin-smartlinker';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This monorepo hosts the Docusaurus plugin and remark helper used by the example 
 ### 1. Install the packages
 
 ```bash
-pnpm add github:smartlinkmed/docusaurus-plugin-smartlinker
+pnpm add github:Uli-Z/docusaurus-plugin-smartlinker
 ```
 
 Use your preferred package manager; pnpm is shown because the example site relies on it. Installing straight from GitHub pulls

--- a/examples/site/docs/demo.mdx
+++ b/examples/site/docs/demo.mdx
@@ -22,7 +22,7 @@ description: See how terms auto-link to docs with hover tooltips in seconds.
 ## Minimal setup (snippet)
 
 ```ts title="docusaurus.config.ts"
-import remarkLinkifyMed from 'remark-linkify-med';
+import remarkLinkifyMed from 'docusaurus-plugin-smartlinker/remark';
 import { createFsIndexProvider } from 'docusaurus-plugin-smartlinker';
 import { join } from 'node:path';
 

--- a/examples/site/docusaurus.config.ts
+++ b/examples/site/docusaurus.config.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const [repoOwner = 'smartlinkmed'] =
+const [repoOwner = 'Uli-Z'] =
   process.env.GITHUB_REPOSITORY?.split('/') ?? [];
 const repoName = 'docusaurus-plugin-smartlinker';
 

--- a/examples/site/docusaurus.config.ts
+++ b/examples/site/docusaurus.config.ts
@@ -1,5 +1,5 @@
 import type { Config } from '@docusaurus/types';
-import remarkLinkifyMed from '../../packages/remark-linkify-med/dist/index.js';
+import remarkLinkifyMed from 'docusaurus-plugin-smartlinker/remark';
 import { createFsIndexProvider } from 'docusaurus-plugin-smartlinker';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';

--- a/examples/site/package.json
+++ b/examples/site/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@docusaurus/core": "^3.0.0",
     "@docusaurus/preset-classic": "^3.0.0",
-    "docusaurus-plugin-smartlinker": "link:../..",
+    "docusaurus-plugin-smartlinker": "file:../..",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/examples/site/package.json
+++ b/examples/site/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@docusaurus/core": "^3.0.0",
     "@docusaurus/preset-classic": "^3.0.0",
-    "docusaurus-plugin-smartlinker": "file:../../packages/docusaurus-plugin-smartlinker",
+    "docusaurus-plugin-smartlinker": "link:../..",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,26 @@
 {
-  "name": "smartlinker-monorepo",
+  "name": "docusaurus-plugin-smartlinker",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "smartlinker-monorepo",
+      "name": "docusaurus-plugin-smartlinker",
+      "version": "0.0.0",
       "workspaces": [
         "packages/*",
         "examples/site"
       ],
+      "dependencies": {
+        "@docusaurus/mdx-loader": "^3.0.0",
+        "@mdx-js/mdx": "^3.1.1",
+        "@mdx-js/react": "^3.1.1",
+        "@radix-ui/react-tooltip": "^1.2.8",
+        "gray-matter": "^4.0.3",
+        "react-markdown": "^9.0.3",
+        "unist-util-visit": "^5.0.0",
+        "zod": "^3.23.0"
+      },
       "devDependencies": {
         "@docusaurus/types": "^3.8.1",
         "@types/react": "^19.1.12",
@@ -17,6 +29,12 @@
       },
       "engines": {
         "node": ">=18 <25"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^3.0.0",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "unified": "^11.0.0"
       }
     },
     "examples/site": {
@@ -24,7 +42,7 @@
       "dependencies": {
         "@docusaurus/core": "^3.0.0",
         "@docusaurus/preset-classic": "^3.0.0",
-        "docusaurus-plugin-smartlinker": "file:../../packages/docusaurus-plugin-smartlinker",
+        "docusaurus-plugin-smartlinker": "file:../..",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       }
@@ -4386,6 +4404,14 @@
         "@hapi/hoek": "^9.0.0"
       }
     },
+    "node_modules/@internal/docusaurus-plugin-smartlinker": {
+      "resolved": "packages/docusaurus-plugin-smartlinker",
+      "link": true
+    },
+    "node_modules/@internal/remark-linkify-med": {
+      "resolved": "packages/remark-linkify-med",
+      "link": true
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -8662,7 +8688,7 @@
       }
     },
     "node_modules/docusaurus-plugin-smartlinker": {
-      "resolved": "packages/docusaurus-plugin-smartlinker",
+      "resolved": "",
       "link": true
     },
     "node_modules/dom-accessibility-api": {
@@ -16924,10 +16950,6 @@
         "url": "https://opencollective.com/unified"
       }
     },
-    "node_modules/remark-linkify-med": {
-      "resolved": "packages/remark-linkify-med",
-      "link": true
-    },
     "node_modules/remark-mdx": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/remark-mdx/-/remark-mdx-3.1.1.tgz",
@@ -19843,6 +19865,7 @@
       }
     },
     "packages/docusaurus-plugin-smartlinker": {
+      "name": "@internal/docusaurus-plugin-smartlinker",
       "version": "0.0.0",
       "dependencies": {
         "@docusaurus/mdx-loader": "^3.0.0",
@@ -19868,6 +19891,7 @@
       }
     },
     "packages/remark-linkify-med": {
+      "name": "@internal/remark-linkify-med",
       "version": "0.0.0",
       "devDependencies": {
         "@types/mdast": "^4.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,8 @@
 {
-  "name": "smartlinker-monorepo",
-  "private": true,
+  "name": "docusaurus-plugin-smartlinker",
+  "version": "0.0.0",
+  "description": "Smartlinker tooling for Docusaurus (plugin + remark helper).",
+  "type": "module",
   "workspaces": [
     "packages/*",
     "examples/site"
@@ -9,14 +11,53 @@
   "engines": {
     "node": ">=18 <25"
   },
+  "main": "./packages/docusaurus-plugin-smartlinker/dist/index.js",
+  "types": "./packages/docusaurus-plugin-smartlinker/dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./packages/docusaurus-plugin-smartlinker/dist/index.d.ts",
+      "import": "./packages/docusaurus-plugin-smartlinker/dist/index.js",
+      "default": "./packages/docusaurus-plugin-smartlinker/dist/index.js"
+    },
+    "./theme": "./packages/docusaurus-plugin-smartlinker/dist/theme/index.js",
+    "./theme/styles.css": "./packages/docusaurus-plugin-smartlinker/dist/theme/styles.css",
+    "./theme/*": "./packages/docusaurus-plugin-smartlinker/dist/theme/runtime/*",
+    "./remark": {
+      "types": "./packages/remark-linkify-med/dist/index.d.ts",
+      "import": "./packages/remark-linkify-med/dist/index.js",
+      "default": "./packages/remark-linkify-med/dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "packages/docusaurus-plugin-smartlinker/dist",
+    "packages/remark-linkify-med/dist"
+  ],
   "scripts": {
-    "build": "npm run build --workspace docusaurus-plugin-smartlinker --workspace remark-linkify-med",
-    "test": "npm run test --workspace docusaurus-plugin-smartlinker --workspace remark-linkify-med",
+    "build": "npm run build --workspace=@internal/docusaurus-plugin-smartlinker --workspace=@internal/remark-linkify-med",
+    "test": "npm run test --workspace=@internal/docusaurus-plugin-smartlinker --workspace=@internal/remark-linkify-med",
     "lint": "echo \"@(optional) add eslint later\"",
     "site:dev": "npm run dev --workspace @examples/site",
     "site:build": "npm run build --workspace @examples/site",
     "site:serve": "npm run serve --workspace @examples/site",
-    "reset": "rm -rf node_modules packages/*/node_modules examples/site/node_modules && npm install && npm run build && npm run build --workspace @examples/site"
+    "reset": "rm -rf node_modules packages/*/node_modules examples/site/node_modules && npm install && npm run build && npm run build --workspace @examples/site",
+    "prepare": "npm run build"
+  },
+  "peerDependencies": {
+    "@docusaurus/core": "^3.0.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "unified": "^11.0.0"
+  },
+  "dependencies": {
+    "@docusaurus/mdx-loader": "^3.0.0",
+    "@mdx-js/mdx": "^3.1.1",
+    "@mdx-js/react": "^3.1.1",
+    "@radix-ui/react-tooltip": "^1.2.8",
+    "gray-matter": "^4.0.3",
+    "react-markdown": "^9.0.3",
+    "unist-util-visit": "^5.0.0",
+    "zod": "^3.23.0"
   },
   "devDependencies": {
     "@docusaurus/types": "^3.8.1",

--- a/packages/docusaurus-plugin-smartlinker/package.json
+++ b/packages/docusaurus-plugin-smartlinker/package.json
@@ -9,7 +9,12 @@
     ".": "./dist/index.js",
     "./theme": "./dist/theme/index.js",
     "./theme/styles.css": "./dist/theme/styles.css",
-    "./theme/*": "./dist/theme/runtime/*"
+    "./theme/*": "./dist/theme/runtime/*",
+    "./remark": {
+      "types": "../remark-linkify-med/dist/index.d.ts",
+      "import": "../remark-linkify-med/dist/index.js",
+      "default": "../remark-linkify-med/dist/index.js"
+    }
   },
   "files": [
     "dist"

--- a/packages/docusaurus-plugin-smartlinker/package.json
+++ b/packages/docusaurus-plugin-smartlinker/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "docusaurus-plugin-smartlinker",
+  "name": "@internal/docusaurus-plugin-smartlinker",
+  "private": true,
   "version": "0.0.0",
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/docusaurus-plugin-smartlinker/src/fsIndexProvider.ts
+++ b/packages/docusaurus-plugin-smartlinker/src/fsIndexProvider.ts
@@ -24,7 +24,7 @@ export interface IndexProvider {
 }
 
 /**
- * Create a remark-linkify-med IndexProvider by scanning the file system
+ * Create a docusaurus-plugin-smartlinker/remark IndexProvider by scanning the file system
  * for MD/MDX files and parsing their frontmatter.
  */
 export function createFsIndexProvider(opts: FsIndexProviderOptions): IndexProvider {

--- a/packages/remark-linkify-med/package.json
+++ b/packages/remark-linkify-med/package.json
@@ -1,5 +1,6 @@
 {
-  "name": "remark-linkify-med",
+  "name": "@internal/remark-linkify-med",
+  "private": true,
   "version": "0.0.0",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^3.0.0
         version: 3.8.1(@algolia/client-search@5.37.0)(@mdx-js/react@3.1.1(@types/react@19.1.13)(react@18.3.1))(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.2)
       docusaurus-plugin-smartlinker:
-        specifier: link:../..
-        version: link:../..
+        specifier: file:../..
+        version: file:(@docusaurus/core@3.8.1(@mdx-js/react@3.1.1(@types/react@19.1.13)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2))(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(unified@11.0.5)
       react:
         specifier: ^18.2.0
         version: 18.3.1
@@ -2932,6 +2932,15 @@ packages:
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
     engines: {node: '>=6'}
+
+  'docusaurus-plugin-smartlinker@file:':
+    resolution: {directory: '', type: directory}
+    engines: {node: '>=18 <25'}
+    peerDependencies:
+      '@docusaurus/core': ^3.0.0
+      react: ^18.2.0
+      react-dom: ^18.2.0
+      unified: ^11.0.0
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -9364,6 +9373,29 @@ snapshots:
   dns-packet@5.6.1:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
+
+  docusaurus-plugin-smartlinker@file:(@docusaurus/core@3.8.1(@mdx-js/react@3.1.1(@types/react@19.1.13)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2))(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(unified@11.0.5):
+    dependencies:
+      '@docusaurus/core': 3.8.1(@mdx-js/react@3.1.1(@types/react@19.1.13)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
+      '@docusaurus/mdx-loader': 3.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mdx-js/mdx': 3.1.1
+      '@mdx-js/react': 3.1.1(@types/react@19.1.13)(react@18.3.1)
+      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      gray-matter: 4.0.3
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-markdown: 9.1.0(@types/react@19.1.13)(react@18.3.1)
+      unified: 11.0.5
+      unist-util-visit: 5.0.0
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - '@swc/core'
+      - '@types/react'
+      - '@types/react-dom'
+      - esbuild
+      - supports-color
+      - uglify-js
+      - webpack-cli
 
   dom-accessibility-api@0.5.16: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -15,6 +15,43 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      '@docusaurus/core':
+        specifier: ^3.0.0
+        version: 3.8.1(@mdx-js/react@3.1.1(@types/react@19.1.13)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
+      '@docusaurus/mdx-loader':
+        specifier: ^3.0.0
+        version: 3.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@mdx-js/mdx':
+        specifier: ^3.1.1
+        version: 3.1.1
+      '@mdx-js/react':
+        specifier: ^3.1.1
+        version: 3.1.1(@types/react@19.1.13)(react@18.3.1)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
+      react:
+        specifier: ^18.2.0
+        version: 18.3.1
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.3.1(react@18.3.1)
+      react-markdown:
+        specifier: ^9.0.3
+        version: 9.1.0(@types/react@19.1.13)(react@18.3.1)
+      unified:
+        specifier: ^11.0.0
+        version: 11.0.5
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
     devDependencies:
       '@docusaurus/types':
         specifier: ^3.8.1
@@ -38,8 +75,8 @@ importers:
         specifier: ^3.0.0
         version: 3.8.1(@algolia/client-search@5.37.0)(@mdx-js/react@3.1.1(@types/react@19.1.13)(react@18.3.1))(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.2)
       docusaurus-plugin-smartlinker:
-        specifier: file:../../packages/docusaurus-plugin-smartlinker
-        version: link:../../packages/docusaurus-plugin-smartlinker
+        specifier: link:../..
+        version: link:../..
       react:
         specifier: ^18.2.0
         version: 18.3.1


### PR DESCRIPTION
## Summary
- expose the repo root as the distributable `docusaurus-plugin-smartlinker` package with subpath exports
- keep the existing plugin and remark code as private workspaces and point the example site/docs at the new entry points
- document installing from GitHub now that both modules ship together

## Testing
- pnpm run test
- pnpm site:build

------
https://chatgpt.com/codex/tasks/task_e_68cc40da62b883318bb4d4420bf38e36