### PR TITLE
Fix GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy-example-site.yml
+++ b/.github/workflows/deploy-example-site.yml
@@ -7,6 +7,12 @@ on:
       - work
   workflow_dispatch:
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  actions: read
+
 concurrency:
   group: pages
   cancel-in-progress: true
@@ -14,22 +20,18 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pages: write
-      id-token: write
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Use Node.js 20
+      - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: npm
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Build packages
         run: npm run build
@@ -48,9 +50,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: build
-    permissions:
-      pages: write
-      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary
- configure workflow-wide permissions required by GitHub Pages
- switch the deployment pipeline to npm with cached installs
- keep the deploy job that publishes the uploaded artifact

## Testing
- not run (workflow-only change)

------
https://chatgpt.com/codex/tasks/task_e_68cc420aec0083318da49235b31fe145