### PR TITLE
Add navbar action icons with about modal

### DIFF
--- a/examples/site/src/components/AboutModal.tsx
+++ b/examples/site/src/components/AboutModal.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import Link from '@docusaurus/Link';
+import useIsBrowser from '@docusaurus/useIsBrowser';
+
+export interface AboutModalProps {
+  open: boolean;
+  onClose: () => void;
+}
+
+const MODAL_ID = 'smartlinker-about-modal';
+
+export default function AboutModal({ open, onClose }: AboutModalProps) {
+  const isBrowser = useIsBrowser();
+  const closeButtonRef = React.useRef<HTMLButtonElement | null>(null);
+  const lastFocusedElement = React.useRef<HTMLElement | null>(null);
+
+  React.useEffect(() => {
+    if (!isBrowser) {
+      return undefined;
+    }
+
+    if (open) {
+      lastFocusedElement.current = document.activeElement as HTMLElement | null;
+      const handleKey = (event: KeyboardEvent) => {
+        if (event.key === 'Escape') {
+          onClose();
+        }
+      };
+      document.addEventListener('keydown', handleKey);
+      requestAnimationFrame(() => closeButtonRef.current?.focus());
+      document.body.classList.add('sl-navbarModal--open');
+      return () => {
+        document.body.classList.remove('sl-navbarModal--open');
+        document.removeEventListener('keydown', handleKey);
+        lastFocusedElement.current?.focus?.();
+      };
+    }
+
+    return undefined;
+  }, [isBrowser, onClose, open]);
+
+  const handleBackdropClick = React.useCallback(
+    (event: React.MouseEvent<HTMLDivElement>) => {
+      if (event.target === event.currentTarget) {
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  if (!isBrowser || !open) {
+    return null;
+  }
+
+  return ReactDOM.createPortal(
+    <div
+      className="sl-navbarModal__backdrop"
+      role="presentation"
+      onClick={handleBackdropClick}
+    >
+      <div
+        className="sl-navbarModal"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={`${MODAL_ID}-title`}
+      >
+        <header className="sl-navbarModal__header">
+          <h2 id={`${MODAL_ID}-title`} className="sl-navbarModal__title">
+            Über Smartlinker
+          </h2>
+          <button
+            type="button"
+            ref={closeButtonRef}
+            className="sl-navbarModal__close"
+            onClick={onClose}
+            aria-label="Dialog schließen"
+          >
+            <span aria-hidden="true">×</span>
+          </button>
+        </header>
+        <div className="sl-navbarModal__body">
+          <p>
+            Smartlinker verknüpft medizinische Begriffe automatisch mit passenden
+            Dokumenten und liefert sofort Tooltip-Hinweise für einen schnellen Kontext.
+          </p>
+          <p>
+            Weitere Informationen findest du auf der{' '}
+            <Link to="https://github.com/Uli-Z/docusaurus-plugin-smartlinker" target="_blank" rel="noopener noreferrer">
+              GitHub-Seite des Projekts
+            </Link>
+            .
+          </p>
+          <p className="sl-navbarModal__license">Lizenz: MIT-Lizenz.</p>
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}

--- a/examples/site/src/components/NavbarActionIcons.tsx
+++ b/examples/site/src/components/NavbarActionIcons.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import AboutModal from './AboutModal';
+
+const ICON_SIZE = 20;
+
+interface IconButtonProps {
+  id: string;
+  label: string;
+  onClick?: () => void;
+  children: React.ReactNode;
+}
+
+function SrOnly({ children }: { children: React.ReactNode }) {
+  return <span className="sl-navbarIconButton__sr-only">{children}</span>;
+}
+
+function IconButton({ id, label, onClick, children }: IconButtonProps) {
+  return (
+    <button
+      type="button"
+      id={id}
+      className="sl-navbarIconButton"
+      aria-label={label}
+      title={label}
+      onClick={onClick}
+    >
+      {children}
+      <SrOnly>{label}</SrOnly>
+    </button>
+  );
+}
+
+function OptionsIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={ICON_SIZE}
+      height={ICON_SIZE}
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M12 9.5A2.5 2.5 0 1 0 12 14.5 2.5 2.5 0 0 0 12 9.5Zm9.25 2.062v.876a1 1 0 0 1-.575.911l-1.516.698a6.98 6.98 0 0 1-.644 1.554l.22 1.66a1 1 0 0 1-.99 1.128h-2.02a1 1 0 0 1-.942-.658l-.561-1.51a7.077 7.077 0 0 1-1.59 0l-.561 1.51a1 1 0 0 1-.943.658H9.106a1 1 0 0 1-.99-1.128l.219-1.66a6.98 6.98 0 0 1-.644-1.554l-1.516-.698a1 1 0 0 1-.575-.911v-.876a1 1 0 0 1 .575-.911l1.516-.698a6.98 6.98 0 0 1 .644-1.554l-.219-1.66a1 1 0 0 1 .99-1.128h2.02a1 1 0 0 1 .943.658l.561 1.51a7.077 7.077 0 0 1 1.59 0l.561-1.51a1 1 0 0 1 .942-.658h2.02a1 1 0 0 1 .99 1.128l-.22 1.66c.3.486.515 1.01.644 1.554l1.516.698a1 1 0 0 1 .575.911Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+function HelpIcon(props: React.SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={ICON_SIZE}
+      height={ICON_SIZE}
+      aria-hidden="true"
+      focusable="false"
+      {...props}
+    >
+      <path
+        d="M12 2a10 10 0 1 0 10 10A10.011 10.011 0 0 0 12 2Zm.01 15.25a1.25 1.25 0 1 1 1.25-1.25 1.25 1.25 0 0 1-1.25 1.25Zm1.772-6.208c-.499.482-.772.754-.772 1.958a1 1 0 0 1-2 0c0-2.102.961-3.019 1.675-3.702.647-.618.915-.876.915-1.548a1.6 1.6 0 0 0-1.6-1.6 1.559 1.559 0 0 0-1.6 1.486 1 1 0 0 1-2-.119A3.559 3.559 0 0 1 12.015 5a3.6 3.6 0 0 1 3.6 3.6c.001 1.607-.836 2.38-1.833 3.442Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+}
+
+export default function NavbarActionIcons() {
+  const [isAboutOpen, setIsAboutOpen] = React.useState(false);
+
+  const handleOptionsClick = React.useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const customHandler = (window as unknown as {
+      openSmartlinkerOptions?: () => void;
+    }).openSmartlinkerOptions;
+    if (typeof customHandler === 'function') {
+      customHandler();
+      return;
+    }
+
+    const fallbackTrigger = document.querySelector<HTMLElement>(
+      '[data-smartlinker-options-trigger]'
+    );
+    if (fallbackTrigger) {
+      fallbackTrigger.click();
+      return;
+    }
+
+    window.dispatchEvent(new CustomEvent('smartlinker:toggle-options'));
+  }, []);
+
+  return (
+    <>
+      <div className="navbar__item navbar__item--icon">
+        <IconButton id="smartlinker-options" label="Optionen" onClick={handleOptionsClick}>
+          <OptionsIcon />
+        </IconButton>
+      </div>
+      <div className="navbar__item navbar__item--icon">
+        <IconButton id="smartlinker-about" label="About & Hilfe" onClick={() => setIsAboutOpen(true)}>
+          <HelpIcon />
+        </IconButton>
+      </div>
+      <AboutModal open={isAboutOpen} onClose={() => setIsAboutOpen(false)} />
+    </>
+  );
+}

--- a/examples/site/src/css/custom.css
+++ b/examples/site/src/css/custom.css
@@ -57,3 +57,122 @@ html[data-theme='dark'] .markdown .lm-smartlink:hover {
 .markdown .lm-tooltip-content {
   line-height: 1.5;
 }
+
+/* Navbar action icons */
+.navbar__item.navbar__item--icon {
+  display: inline-flex;
+  align-items: center;
+}
+
+.sl-navbarIconButton {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border: none;
+  border-radius: 999px;
+  background: transparent;
+  color: inherit;
+  cursor: pointer;
+  transition: background 150ms ease, color 150ms ease;
+}
+
+.sl-navbarIconButton:hover,
+.sl-navbarIconButton:focus-visible {
+  background: var(--ifm-menu-color-background-hover, rgba(107, 114, 128, 0.15));
+  outline: none;
+}
+
+.sl-navbarIconButton svg {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
+.sl-navbarIconButton__sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+/* Modal styles */
+body.sl-navbarModal--open {
+  overflow: hidden;
+}
+
+.sl-navbarModal__backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: var(--ifm-z-index-overlay, 400);
+}
+
+.sl-navbarModal {
+  background: var(--ifm-background-surface-color);
+  color: var(--ifm-font-color-base);
+  border-radius: var(--ifm-global-radius, 0.5rem);
+  box-shadow: var(--ifm-shadow-md, 0 20px 45px rgba(15, 23, 42, 0.25));
+  max-width: 28rem;
+  width: 100%;
+  padding: 1.5rem;
+}
+
+html[data-theme='dark'] .sl-navbarModal {
+  box-shadow: var(--ifm-shadow-lg, 0 20px 45px rgba(15, 23, 42, 0.5));
+}
+
+.sl-navbarModal__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.sl-navbarModal__title {
+  font-size: 1.25rem;
+  margin: 0;
+}
+
+.sl-navbarModal__close {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1.5rem;
+  line-height: 1;
+  cursor: pointer;
+  padding: 0.25rem;
+  border-radius: 0.25rem;
+}
+
+.sl-navbarModal__close:hover,
+.sl-navbarModal__close:focus-visible {
+  background: var(--ifm-menu-color-background-hover, rgba(107, 114, 128, 0.2));
+  outline: none;
+}
+
+.sl-navbarModal__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: 0.95rem;
+}
+
+.sl-navbarModal__license {
+  font-weight: 600;
+}
+
+@media (max-width: 600px) {
+  .sl-navbarModal {
+    padding: 1.25rem;
+  }
+}

--- a/examples/site/src/theme/Navbar/Content/index.tsx
+++ b/examples/site/src/theme/Navbar/Content/index.tsx
@@ -1,0 +1,105 @@
+import React from 'react';
+import clsx from 'clsx';
+import {
+  useThemeConfig,
+  ErrorCauseBoundary,
+  ThemeClassNames,
+} from '@docusaurus/theme-common';
+import {
+  splitNavbarItems,
+  useNavbarMobileSidebar,
+} from '@docusaurus/theme-common/internal';
+import NavbarItem from '@theme/NavbarItem';
+import NavbarColorModeToggle from '@theme/Navbar/ColorModeToggle';
+import SearchBar from '@theme/SearchBar';
+import NavbarMobileSidebarToggle from '@theme/Navbar/MobileSidebar/Toggle';
+import NavbarLogo from '@theme/Navbar/Logo';
+import NavbarSearch from '@theme/Navbar/Search';
+import NavbarActionIcons from '@site/src/components/NavbarActionIcons';
+import styles from './styles.module.css';
+
+function useNavbarItems() {
+  return useThemeConfig().navbar.items;
+}
+
+function NavbarItems({ items }: { items: any[] }) {
+  return (
+    <>
+      {items.map((item, index) => (
+        <ErrorCauseBoundary
+          key={index}
+          onError={(error) =>
+            new Error(
+              `A theme navbar item failed to render.\n` +
+                `Please double-check the following navbar item (themeConfig.navbar.items) of your Docusaurus config:\n` +
+                `${JSON.stringify(item, null, 2)}`,
+              { cause: error }
+            )
+          }
+        >
+          <NavbarItem {...item} />
+        </ErrorCauseBoundary>
+      ))}
+    </>
+  );
+}
+
+function NavbarContentLayout({
+  left,
+  right,
+}: {
+  left: React.ReactNode;
+  right: React.ReactNode;
+}) {
+  return (
+    <div className="navbar__inner">
+      <div
+        className={clsx(
+          ThemeClassNames.layout.navbar.containerLeft,
+          'navbar__items'
+        )}
+      >
+        {left}
+      </div>
+      <div
+        className={clsx(
+          ThemeClassNames.layout.navbar.containerRight,
+          'navbar__items navbar__items--right'
+        )}
+      >
+        {right}
+      </div>
+    </div>
+  );
+}
+
+export default function NavbarContent() {
+  const mobileSidebar = useNavbarMobileSidebar();
+  const items = useNavbarItems();
+  const [leftItems, rightItems] = splitNavbarItems(items);
+  const searchBarItem = items.find((item) => item.type === 'search');
+
+  return (
+    <NavbarContentLayout
+      left={
+        <>
+          {!mobileSidebar.disabled && <NavbarMobileSidebarToggle />}
+          <NavbarLogo />
+          <NavbarItems items={leftItems} />
+        </>
+      }
+      right={
+        <>
+          <NavbarItems items={rightItems} />
+          <NavbarActionIcons />
+          <NavbarColorModeToggle className={styles.colorModeToggle} />
+          {!searchBarItem && (
+            <NavbarSearch>
+              <SearchBar />
+            </NavbarSearch>
+          )}
+        </>
+      }
+    />
+  );
+}

--- a/examples/site/src/theme/Navbar/Content/styles.module.css
+++ b/examples/site/src/theme/Navbar/Content/styles.module.css
@@ -1,0 +1,23 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+/*
+Hide color mode toggle in small viewports
+ */
+@media (max-width: 996px) {
+  .colorModeToggle {
+    display: none;
+  }
+}
+
+/*
+Restore some Infima style that broke with CSS Cascade Layers
+See https://github.com/facebook/docusaurus/pull/11142
+ */
+:global(.navbar__items--right) > :last-child {
+  padding-right: 0;
+}


### PR DESCRIPTION
## Summary
- replace the navbar options label with icon buttons and extend the navbar content override to render them
- add an about/help modal that explains Smartlinker, links to GitHub, and shows the MIT license hint
- style the new navbar icons and modal so they blend with the existing theme

## Testing
- npm run site:build
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68ce7c1d22f0833183a55dcf89719f77