### PR TITLE
docs: clarify project overview in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,90 @@
 # docusaurus-plugin-smartlinker
 
-Smartlinker brings tooltip-powered cross-linking to Docusaurus v3. The root package bundles both the Docusaurus plugin and the accompanying remark plugin so projects can install a single dependency and get consistent SmartLink rendering across Markdown and MDX content.
+Smartlinker is a Docusaurus v3 plugin (with an accompanying remark helper) that turns frontmatter metadata into automatic cross-links. By indexing each document's `id`, `slug`, synonyms, icon, and short note, it renders consistent SmartLinks with contextual tooltips wherever those terms appear in Markdown or MDX.
+
+## Features at a glance
+
+- **Frontmatter-driven linking.** Scan `id`, `slug`, `smartlink-terms`, optional `smartlink-icon`, and optional `smartlink-short-note` fields and keep the registry in sync with your filesystem.
+- **Tooltip notes compiled from MDX.** Convert `smartlink-short-note` snippets into ready-to-render React components so domain tips appear inline in the tooltip.
+- **Collision-aware registry generation.** Build a tooltip registry that resolves slug collisions based on folder proximity while preserving deterministic output.
+- **Single `<SmartLink/>` component everywhere.** Inject the runtime so docs, pages, admonitions, and tables all share the same tooltip behavior (including emoji or SVG icons and dark-mode styling).
+- **Remark plugin parity.** Bundle a remark transformer so Markdown handled outside of the Docusaurus plugin (e.g., classic preset docs/pages) receives identical SmartLink treatment.
+
+## Quick start
+
+1. **Install the package** (ships prebuilt via the root `prepare` script):
+
+   ```bash
+   npm install github:Uli-Z/docusaurus-plugin-smartlinker
+   ```
+
+2. **Register the plugins** in your `docusaurus.config.ts` and create an index provider that points to the content folders you want to scan:
+
+   ```ts
+   import remarkSmartlinker from 'docusaurus-plugin-smartlinker/remark';
+   import {
+     createFsIndexProvider,
+     type PluginOptions,
+   } from 'docusaurus-plugin-smartlinker';
+   import { dirname, join } from 'node:path';
+   import { fileURLToPath } from 'node:url';
+
+   const __dirname = dirname(fileURLToPath(import.meta.url));
+
+   const SmartlinkerIndex = createFsIndexProvider({
+     roots: [join(__dirname, 'docs')],
+     slugPrefix: '/docs',
+   });
+
+   const config = {
+     presets: [
+       [
+         'classic',
+         {
+           docs: {
+             remarkPlugins: [[remarkSmartlinker, { index: SmartlinkerIndex }]],
+           },
+           pages: {
+             remarkPlugins: [[remarkSmartlinker, { index: SmartlinkerIndex }]],
+           },
+         },
+       ],
+     ],
+     plugins: [
+       [
+         'docusaurus-plugin-smartlinker',
+         {
+           icons: {
+             pill: 'emoji:💊',
+             bug: '/img/bug.svg',
+           },
+           defaultIcon: 'pill',
+           tooltipComponents: {
+             DrugTip: '@site/src/components/DrugTip',
+           },
+         } satisfies PluginOptions,
+       ],
+     ],
+   };
+   ```
+
+3. **Annotate your docs** with SmartLink metadata so the index provider can pick up synonyms, icons, and tooltip notes:
+
+   ```mdx
+   ---
+   id: amoxicillin
+   slug: /antibiotics/amoxicillin
+   smartlink-terms:
+     - Amoxi
+     - Amoxicillin
+   smartlink-icon: pill
+   smartlink-short-note: |
+     **Aminopenicillin.** Offers good oral bioavailability.
+     <DrugTip note="Take with food" />
+   ---
+   ```
+
+Smartlinker builds a registry from these front matter fields, injects `<SmartLink/>` nodes during the remark phase, and renders hover/tap tooltips at runtime.
 
 ## Packages
 
@@ -10,90 +94,16 @@ This repository publishes a single installable package:
 
 The workspaces in `packages/` house the source code for the plugin and the remark transform. They build into `dist/` and are included in the published tarball via the root `prepare` script.
 
-## Features
+## Solved coding challenges
 
-- Scan Markdown and MDX front matter (`id`, `slug`, `smartlink-terms`, optional `smartlink-icon`, optional `smartlink-short-note`).
-- Compile optional `smartlink-short-note` strings from inline MDX to ready-to-render React components.
-- Generate a tooltip registry with proximity-aware collision handling and icon metadata.
-- Inject a shared `<SmartLink/>` component so linked terms render consistently in docs, pages, admonitions, and tables.
-- Display optional icons (including emoji) and MDX tooltips with dark-mode aware styling.
-- Provide a remark plugin so Markdown content processed by Docusaurus receives the same SmartLink treatment.
+Smartlinker tackles the tricky pieces required for automatic cross-linking in Docusaurus:
 
-## Installation
-
-The package can be consumed directly from GitHub; the `prepare` script builds the bundled workspaces so the `dist/` artifacts ship with the install:
-
-```bash
-npm install github:Uli-Z/docusaurus-plugin-smartlinker
-```
-
-### Docusaurus configuration
-
-```ts
-import remarkSmartlinker from 'docusaurus-plugin-smartlinker/remark';
-import {
-  createFsIndexProvider,
-  type PluginOptions,
-} from 'docusaurus-plugin-smartlinker';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-const SmartlinkerIndex = createFsIndexProvider({
-  roots: [join(__dirname, 'docs')],
-  slugPrefix: '/docs',
-});
-
-const config = {
-  presets: [
-    [
-      'classic',
-      {
-        docs: {
-          remarkPlugins: [[remarkSmartlinker, { index: SmartlinkerIndex }]],
-        },
-        pages: {
-          remarkPlugins: [[remarkSmartlinker, { index: SmartlinkerIndex }]],
-        },
-      },
-    ],
-  ],
-  plugins: [
-    [
-      'docusaurus-plugin-smartlinker',
-      {
-        icons: {
-          pill: 'emoji:💊',
-          bug: '/img/bug.svg',
-        },
-        defaultIcon: 'pill',
-        tooltipComponents: {
-          DrugTip: '@site/src/components/DrugTip',
-        },
-      } satisfies PluginOptions,
-    ],
-  ],
-};
-```
-
-Annotate each Markdown or MDX document you want to index with SmartLink metadata:
-
-```mdx
----
-id: amoxicillin
-slug: /antibiotics/amoxicillin
-smartlink-terms:
-  - Amoxi
-  - Amoxicillin
-smartlink-icon: pill
-smartlink-short-note: |
-  **Aminopenicillin.** Offers good oral bioavailability.
-  <DrugTip note="Take with food" />
----
-```
-
-Smartlinker builds a registry from these front matter fields, injects `<SmartLink/>` nodes during the remark phase, and renders hover/tap tooltips at runtime.
+- **Robust frontmatter loader.** Uses `gray-matter` plus `zod` validation to normalize metadata and emit actionable warnings instead of crashing on malformed content.
+- **Path distance & collision resolution.** Computes proximity scores between files so the closest document wins when multiple entries expose the same synonym.
+- **Deterministic tooltip codegen.** Compiles MDX `smartlink-short-note` blocks into SSR-safe TSX modules and materializes a registry that can be imported by both the plugin runtime and the remark transformer.
+- **Icon resolver with dark-mode awareness.** Validates configuration, applies defaults, and maps emoji or SVG assets consistently across the build outputs.
+- **Synonym-aware remark transform.** Walks Markdown/MDX ASTs to replace matched text with `<SmartLink/>` nodes while preserving existing formatting.
+- **Docusaurus SSR compatibility.** Keeps the build pipeline compatible with Webpack's server rendering requirements (e.g., avoiding root-level `"type": "module"`) so the example site and plugin compile cleanly.
 
 ## Verification scripts
 


### PR DESCRIPTION
## Summary
- clarify the README introduction to highlight Smartlinker’s frontmatter-driven cross-linking purpose
- replace the feature section with a concise bullet list and add a quick start guide
- document the key engineering challenges solved while building the plugin

## Testing
- not run (docs-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ceaec22ef48331860d02f93a50bb89