### PR TITLE
Allow React 19 peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
   },
   "peerDependencies": {
     "@docusaurus/core": "^3.0.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0",
     "unified": "^11.0.0"
   },
   "dependencies": {
@@ -68,8 +68,8 @@
   },
   "pnpm": {
     "overrides": {
-      "react": "^18.2.0",
-      "react-dom": "^18.2.0",
+      "react": ">=18.2.0 <20",
+      "react-dom": ">=18.2.0 <20",
       "estree-walker": "^3.0.3",
       "estree-util-build-jsx": "^3.0.1",
       "recma-build-jsx": "^1.0.0",

--- a/packages/docusaurus-plugin-smartlinker/CHANGELOG.md
+++ b/packages/docusaurus-plugin-smartlinker/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- No unreleased changes.
+- Allow React 19 as a peer dependency so installing the plugin in Docusaurus projects using React 19 no longer fails.
 
 ## 0.1.0
 

--- a/packages/docusaurus-plugin-smartlinker/package.json
+++ b/packages/docusaurus-plugin-smartlinker/package.json
@@ -36,8 +36,8 @@
   },
   "peerDependencies": {
     "@docusaurus/core": "^3.0.0",
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react": "^18.2.0 || ^19.0.0",
+    "react-dom": "^18.2.0 || ^19.0.0"
   },
   "dependencies": {
     "@docusaurus/mdx-loader": "^3.0.0",


### PR DESCRIPTION
## Summary
- allow installing the package alongside React 19 by expanding the peer dependency ranges
- align the pnpm override and workspace package metadata and document the change in the changelog

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68ceaf8eb5248331ab1139ba11f99aa3