### PR TITLE
Fix generated module import compatibility

### DIFF
--- a/packages/docusaurus-plugin-smartlinker/src/theme/generated.d.ts
+++ b/packages/docusaurus-plugin-smartlinker/src/theme/generated.d.ts
@@ -7,10 +7,14 @@ declare module '@generated/docusaurus-plugin-smartlinker/default/registry' {
     ShortNote?: ComponentType<{ components?: Record<string, unknown> }>;
   }
   export const registry: Record<string, GeneratedRegistryEntry>;
+  const _default: typeof registry;
+  export default _default;
 }
 
 declare module '@generated/docusaurus-plugin-smartlinker/default/tooltipComponents' {
   import type { ComponentType } from 'react';
   export const tooltipComponents: Record<string, ComponentType<any>>;
+  const _default: typeof tooltipComponents;
+  export default _default;
 }
 

--- a/packages/docusaurus-plugin-smartlinker/src/theme/runtime/generatedRegistry.ts
+++ b/packages/docusaurus-plugin-smartlinker/src/theme/runtime/generatedRegistry.ts
@@ -1,7 +1,5 @@
-import {
-  registry as generatedRegistry,
-  type GeneratedRegistryEntry,
-} from '@generated/docusaurus-plugin-smartlinker/default/registry';
+import * as generated from '@generated/docusaurus-plugin-smartlinker/default/registry';
+import type { GeneratedRegistryEntry } from '@generated/docusaurus-plugin-smartlinker/default/registry';
 
 /**
  * The generated registry lives under the plugin name + plugin id.
@@ -12,4 +10,14 @@ import {
 export const GENERATED_REGISTRY_IMPORT_PATH =
   '@generated/docusaurus-plugin-smartlinker/default/registry';
 
-export { generatedRegistry, type GeneratedRegistryEntry };
+type RegistryModule = {
+  registry?: Record<string, GeneratedRegistryEntry>;
+  default?: Record<string, GeneratedRegistryEntry>;
+};
+
+const moduleApi = generated as RegistryModule;
+
+export const generatedRegistry: Record<string, GeneratedRegistryEntry> =
+  moduleApi.registry ?? moduleApi.default ?? {};
+
+export { type GeneratedRegistryEntry };

--- a/packages/docusaurus-plugin-smartlinker/src/theme/runtime/generatedTooltipComponents.ts
+++ b/packages/docusaurus-plugin-smartlinker/src/theme/runtime/generatedTooltipComponents.ts
@@ -1,3 +1,12 @@
-import { tooltipComponents } from '@generated/docusaurus-plugin-smartlinker/default/tooltipComponents';
+import type { ComponentType } from 'react';
+import * as generated from '@generated/docusaurus-plugin-smartlinker/default/tooltipComponents';
 
-export { tooltipComponents };
+type TooltipComponentsModule = {
+  tooltipComponents?: Record<string, ComponentType<any>>;
+  default?: Record<string, ComponentType<any>>;
+};
+
+const moduleApi = generated as TooltipComponentsModule;
+
+export const tooltipComponents: Record<string, ComponentType<any>> =
+  moduleApi.tooltipComponents ?? moduleApi.default ?? {};


### PR DESCRIPTION
## Summary
- normalize the runtime wrappers so generated tooltip/registry modules always expose named exports
- extend the generated module typings to advertise the optional default export used for fallback

## Testing
- npm run build
- npm test
- npm run site:build
- npm run smoke:git-install

------
https://chatgpt.com/codex/tasks/task_e_68cf0262b8808331a66a222d82e63345