### PR TITLE
Use global store for remark index provider

### DIFF
--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -768,3 +768,15 @@ Refactored the example site's remark integration to use a pure ESM import of `re
 - `npm run build`
 - `npm test`
 - `npm run site:build`
+
+# Status Sync — slugPrefix documentation (2025-02-XX)
+
+## Summary
+
+- Expanded the README to explain how `slugPrefix` rewrites frontmatter slugs for Markdown processed outside Docusaurus and clarified that it does not filter which documents are indexed.
+- Reconfirmed the build so Vitest can resolve the package exports before rerunning the workspace test suite.
+
+## Verification
+
+- `npm run build`
+- `npm test`

--- a/AGENT_LOG.md
+++ b/AGENT_LOG.md
@@ -726,6 +726,20 @@ Refactored the example site's remark integration to use a pure ESM import of `re
 - `pnpm site:build`
 - `npm run smoke:git-install`
 
+# Status Sync — Plugin-managed remark index (2025-02-XX)
+
+## Summary
+
+- Added a shared index provider store that the Docusaurus plugin primes and persists to `.docusaurus`, so the bundled remark transformer no longer needs manual FS scans.
+- Updated the remark transformer to resolve providers from the plugin store or the persisted snapshot and added tests for both plugin-managed and manual modes.
+- Simplified the example configuration and README snippets to drop manual index wiring and rely on the plugin-supplied provider (including the optional `slugPrefix`).
+
+## Verification
+
+- `npm run build`
+- `npm test`
+- `npm run site:build`
+
 # Milestone B: Publishable 0.1.0
 
 ## Summary
@@ -740,3 +754,17 @@ Refactored the example site's remark integration to use a pure ESM import of `re
 - `npm test`
 - `npm run site:build`
 - `npm run smoke:git-install`
+
+# Status Sync — Global index store without filesystem fallback (2025-02-XX)
+
+## Summary
+
+- Simplified the shared index provider store to keep the provider in-memory and mirror it on `globalThis`, so the remark transformer can pick it up without rebuilding a filesystem index or hydrating from snapshots.
+- Updated the remark transformer to lazily derive its matcher/maps whenever the provider changes and tightened the tests to cover plugin-managed indices and the no-provider error case.
+- Ensured the plugin continues to prime the provider during initialization so only the Docusaurus plugin and remark transformer registrations remain in user config.
+
+## Verification
+
+- `npm run build`
+- `npm test`
+- `npm run site:build`

--- a/README.md
+++ b/README.md
@@ -18,20 +18,10 @@ Smartlinker is a Docusaurus v3 plugin (with an accompanying remark helper) that 
    npm install github:Uli-Z/docusaurus-plugin-smartlinker
    ```
 
-2. **Register the plugins** in your `docusaurus.config.js` and create an index provider that points to the content folders you want to scan:
+2. **Register the plugins** in your `docusaurus.config.js`. The Docusaurus plugin now publishes its index automatically, so the remark transformer can be added without extra wiring:
 
    ```js
    import remarkSmartlinker from 'docusaurus-plugin-smartlinker/remark';
-   import { createFsIndexProvider } from 'docusaurus-plugin-smartlinker';
-   import { dirname, join } from 'node:path';
-   import { fileURLToPath } from 'node:url';
-
-   const __dirname = dirname(fileURLToPath(import.meta.url));
-
-   const SmartlinkerIndex = createFsIndexProvider({
-     roots: [join(__dirname, 'docs')],
-     slugPrefix: '/docs',
-   });
 
    export default {
      presets: [
@@ -39,10 +29,10 @@ Smartlinker is a Docusaurus v3 plugin (with an accompanying remark helper) that 
          'classic',
          {
            docs: {
-             remarkPlugins: [[remarkSmartlinker, { index: SmartlinkerIndex }]],
+             remarkPlugins: [remarkSmartlinker],
            },
            pages: {
-             remarkPlugins: [[remarkSmartlinker, { index: SmartlinkerIndex }]],
+             remarkPlugins: [remarkSmartlinker],
            },
          },
        ],
@@ -51,6 +41,7 @@ Smartlinker is a Docusaurus v3 plugin (with an accompanying remark helper) that 
        [
          'docusaurus-plugin-smartlinker',
          {
+           slugPrefix: '/docs',
            icons: {
              pill: 'emoji:💊',
              bug: '/img/bug.svg',
@@ -62,8 +53,8 @@ Smartlinker is a Docusaurus v3 plugin (with an accompanying remark helper) that 
          },
        ],
      ],
-   };
-   ```
+    };
+    ```
 
 3. **Annotate your docs** with SmartLink metadata so the index provider can pick up synonyms, icons, and tooltip notes:
 
@@ -80,6 +71,8 @@ Smartlinker is a Docusaurus v3 plugin (with an accompanying remark helper) that 
      <DrugTip note="Take with food" />
    ---
    ```
+
+If you're processing Markdown outside of the Docusaurus lifecycle, you can still create and pass a manual index provider via `createFsIndexProvider({ roots, slugPrefix })` when calling the remark transformer.
 
 Smartlinker builds a registry from these front matter fields, injects `<SmartLink/>` nodes during the remark phase, and renders hover/tap tooltips at runtime.
 

--- a/README.md
+++ b/README.md
@@ -53,8 +53,19 @@ Smartlinker is a Docusaurus v3 plugin (with an accompanying remark helper) that 
          },
        ],
      ],
-    };
-    ```
+   };
+   ```
+
+   The optional `slugPrefix` controls the base route that Smartlinker
+   prepends to every frontmatter `slug` when it publishes the index for the
+   remark transformer. Keep it aligned with the path where your docs mount
+   (e.g., `routeBasePath: '/docs'`) so an entry with
+   ``slug: /antibiotics/amoxicillin`` resolves to
+   `/docs/antibiotics/amoxicillin` when Markdown is processed outside of
+   Docusaurus. Omitting the option leaves the slugs untouched. The prefix
+   does **not** filter which pages land in the index – any file with
+   `linkify !== false`, a non-empty `smartlink-terms` array, and valid
+   `id`/`slug` metadata is included regardless of this setting.
 
 3. **Annotate your docs** with SmartLink metadata so the index provider can pick up synonyms, icons, and tooltip notes:
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@ Smartlinker 0.1.0 packages the end-to-end tooltip linking pipeline so projects c
 
 - **Docusaurus plugin.** Builds a SmartLink registry from annotated front matter, compiles optional MDX tooltip notes at build time, and wires the theme runtime so links render with icons and accessible hover/tap tooltips out of the box.
 - **Remark integration.** Bundles a remark transform that replaces matching text nodes with `<SmartLink>` elements, skipping code, existing links, and top-level headings to avoid unwanted replacements.
-- **Filesystem index helpers.** Exposes `createFsIndexProvider` so consumers can drive remark from scanned Markdown/MDX files, with optional slug prefixing for docs served from a sub-route.
+- **Filesystem index helpers.** The plugin now registers its index for the bundled remark transformer automatically; `createFsIndexProvider` remains available for standalone Markdown flows (with optional slug prefixing for docs served from a sub-route).
 - **Example site.** Includes an example Docusaurus workspace demonstrating SmartLinks in practice and serving as a manual QA surface.
 
 ## Installation
@@ -21,19 +21,7 @@ Update `docusaurus.config.ts` to register both the plugin and remark helper. A t
 
 ```ts
 import remarkSmartlinker from 'docusaurus-plugin-smartlinker/remark';
-import {
-  createFsIndexProvider,
-  type PluginOptions,
-} from 'docusaurus-plugin-smartlinker';
-import { dirname, join } from 'node:path';
-import { fileURLToPath } from 'node:url';
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-
-const SmartlinkerIndex = createFsIndexProvider({
-  roots: [join(__dirname, 'docs')],
-  slugPrefix: '/docs',
-});
+import { type PluginOptions } from 'docusaurus-plugin-smartlinker';
 
 const config = {
   presets: [
@@ -41,10 +29,10 @@ const config = {
       'classic',
       {
         docs: {
-          remarkPlugins: [[remarkSmartlinker, { index: SmartlinkerIndex }]],
+          remarkPlugins: [remarkSmartlinker],
         },
         pages: {
-          remarkPlugins: [[remarkSmartlinker, { index: SmartlinkerIndex }]],
+          remarkPlugins: [remarkSmartlinker],
         },
       },
     ],
@@ -53,6 +41,7 @@ const config = {
     [
       'docusaurus-plugin-smartlinker',
       {
+        slugPrefix: '/docs',
         icons: {
           pill: 'emoji:💊',
           bug: '/img/bug.svg',

--- a/examples/site/docs/demo.mdx
+++ b/examples/site/docs/demo.mdx
@@ -23,20 +23,14 @@ description: See how terms auto-link to docs with hover tooltips in seconds.
 
 ```ts title="docusaurus.config.ts"
 import remarkSmartlinker from 'docusaurus-plugin-smartlinker/remark';
-import { createFsIndexProvider } from 'docusaurus-plugin-smartlinker';
-import { join } from 'node:path';
-
-const SmartlinkerIndex = createFsIndexProvider({
-  roots: [join(__dirname, 'docs')],
-  slugPrefix: '/docs',
-});
 
 export default {
   presets: [['classic', {
-    docs: { remarkPlugins: [[remarkSmartlinker, { index: SmartlinkerIndex }]] },
-    pages: { remarkPlugins: [[remarkSmartlinker, { index: SmartlinkerIndex }]] },
+    docs: { remarkPlugins: [remarkSmartlinker] },
+    pages: { remarkPlugins: [remarkSmartlinker] },
   }]],
   plugins: [['docusaurus-plugin-smartlinker', {
+    slugPrefix: '/docs',
     icons: { pill: 'emoji:💊', bug: '/img/bug.svg' },
     tooltipComponents: {
       DrugTip: '@site/src/components/DrugTip',

--- a/examples/site/docusaurus.config.ts
+++ b/examples/site/docusaurus.config.ts
@@ -1,6 +1,5 @@
 import type { Config } from '@docusaurus/types';
 import remarkSmartlinker from 'docusaurus-plugin-smartlinker/remark';
-import { createFsIndexProvider } from 'docusaurus-plugin-smartlinker';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -31,11 +30,6 @@ const normalizedBaseUrl = (() => {
   return '/';
 })();
 
-const SmartlinkerIndex = createFsIndexProvider({
-  roots: [join(__dirname, 'docs')],
-  slugPrefix: '/docs',
-});
-
 const config: Config = {
   title: 'Smartlinker Example',
   favicon: 'img/favicon.ico',
@@ -55,11 +49,11 @@ const config: Config = {
       {
         docs: {
           sidebarPath: require.resolve('./sidebars.ts'),
-          remarkPlugins: [[remarkSmartlinker, { index: SmartlinkerIndex }]],
+          remarkPlugins: [remarkSmartlinker],
         },
         blog: false,
         pages: {
-          remarkPlugins: [[remarkSmartlinker, { index: SmartlinkerIndex }]],
+          remarkPlugins: [remarkSmartlinker],
         },
         theme: {
           customCss: join(__dirname, 'src/css/custom.css'),
@@ -79,6 +73,7 @@ const config: Config = {
       tooltipComponents: {
         DrugTip: '@site/src/components/DrugTip',
       },
+      slugPrefix: '/docs',
     }]
   ],
 };

--- a/packages/docusaurus-plugin-smartlinker/src/indexProviderStore.ts
+++ b/packages/docusaurus-plugin-smartlinker/src/indexProviderStore.ts
@@ -1,0 +1,62 @@
+import type { IndexRawEntry } from './types.js';
+import type { IndexProvider, TargetInfo } from './fsIndexProvider.js';
+
+const GLOBAL_KEY = Symbol.for('docusaurus-plugin-smartlinker.indexProvider');
+
+let currentProvider: IndexProvider | undefined;
+
+function readGlobalProvider(): IndexProvider | undefined {
+  const store = globalThis as Record<PropertyKey, unknown>;
+  const value = store[GLOBAL_KEY];
+  if (value && typeof value === 'object') {
+    return value as IndexProvider;
+  }
+  return undefined;
+}
+
+function writeGlobalProvider(provider: IndexProvider | undefined): void {
+  const store = globalThis as Record<PropertyKey, unknown>;
+  if (!provider) {
+    delete store[GLOBAL_KEY];
+  } else {
+    store[GLOBAL_KEY] = provider;
+  }
+}
+
+function toTargets(entries: IndexRawEntry[], slugPrefix: string): TargetInfo[] {
+  return entries.map((entry) => ({
+    id: entry.id,
+    slug: `${slugPrefix}${entry.slug}`,
+    icon: entry.icon,
+    sourcePath: entry.sourcePath,
+    terms: entry.terms,
+  }));
+}
+
+export function setIndexEntries(entries: IndexRawEntry[], slugPrefix?: string): void {
+  const prefix = slugPrefix ?? '';
+  const targets = toTargets(entries, prefix);
+
+  currentProvider = {
+    getAllTargets() {
+      return targets;
+    },
+    getCurrentFilePath(file) {
+      if (file && typeof file.path === 'string') {
+        return file.path;
+      }
+      return '';
+    },
+  };
+
+  writeGlobalProvider(currentProvider);
+}
+
+export function getIndexProvider(): IndexProvider | undefined {
+  return currentProvider ?? readGlobalProvider();
+}
+
+export function clearIndexProvider(): void {
+  currentProvider = undefined;
+  writeGlobalProvider(undefined);
+}

--- a/packages/docusaurus-plugin-smartlinker/src/options.ts
+++ b/packages/docusaurus-plugin-smartlinker/src/options.ts
@@ -43,6 +43,7 @@ export const OptionsSchema = z.object({
       }
       return out;
     }),
+  slugPrefix: TrimmedString.optional(),
 });
 
 export type PluginOptions = z.input<typeof OptionsSchema>;

--- a/packages/remark-linkify-med/src/transform.ts
+++ b/packages/remark-linkify-med/src/transform.ts
@@ -3,6 +3,7 @@ import { visit, SKIP } from 'unist-util-visit';
 import { normalize } from 'node:path';
 import type { Parent } from 'unist';
 import type { Content, Root, Text, PhrasingContent } from 'mdast';
+import { getIndexProvider as getRegisteredIndexProvider } from 'docusaurus-plugin-smartlinker';
 import { buildMatcher, type AutoLinkEntry } from './matcher.js';
 
 export interface TargetInfo {
@@ -19,7 +20,7 @@ export interface IndexProvider {
 }
 
 export interface RemarkSmartlinkerOptions {
-  index: IndexProvider;
+  index?: IndexProvider;
   componentName?: string;
   toAttr?: string;
   iconAttr?: string;
@@ -71,58 +72,88 @@ function toMdxJsxTextElement(
   };
 }
 
-export default function remarkSmartlinker(opts: RemarkSmartlinkerOptions): Transformer {
-  const componentName = opts.componentName ?? 'SmartLink';
-  const toAttr = opts.toAttr ?? 'to';
-  const iconAttr = opts.iconAttr ?? 'icon';
-  const tipKeyAttr = opts.tipKeyAttr ?? 'tipKey';
-  const matchAttr = opts.matchAttr ?? 'match';
-  const shortNoteComponentName = opts.shortNoteComponentName ?? 'LinkifyShortNote';
-  const shortNoteTipKeyAttr = opts.shortNoteTipKeyAttr ?? tipKeyAttr;
-  const shortNotePlaceholder = opts.shortNotePlaceholder ?? '%%SHORT_NOTICE%%';
+export default function remarkSmartlinker(opts?: RemarkSmartlinkerOptions): Transformer {
+  const options = opts ?? {};
 
-  const targets = opts.index.getAllTargets();
+  const componentName = options.componentName ?? 'SmartLink';
+  const toAttr = options.toAttr ?? 'to';
+  const iconAttr = options.iconAttr ?? 'icon';
+  const tipKeyAttr = options.tipKeyAttr ?? 'tipKey';
+  const matchAttr = options.matchAttr ?? 'match';
+  const shortNoteComponentName = options.shortNoteComponentName ?? 'LinkifyShortNote';
+  const shortNoteTipKeyAttr = options.shortNoteTipKeyAttr ?? tipKeyAttr;
+  const shortNotePlaceholder = options.shortNotePlaceholder ?? '%%SHORT_NOTICE%%';
+  type PreparedIndex = {
+    targets: TargetInfo[];
+    matcher: ReturnType<typeof buildMatcher>;
+    claimMap: Map<string, { id: string; slug: string; icon?: string }[]>;
+    targetByPath: Map<string, TargetInfo>;
+    targetById: Map<string, TargetInfo>;
+    targetBySlug: Map<string, TargetInfo>;
+  };
 
-  const termEntries: AutoLinkEntry[] = [];
-  for (const t of targets) {
-    for (const lit of t.terms) {
-      const literal = String(lit ?? '').trim();
-      if (!literal) continue;
-      termEntries.push({ literal, key: `${t.id}::${t.slug}::${t.icon ?? ''}` });
+  let cachedProvider: IndexProvider | undefined;
+  let prepared: PreparedIndex | undefined;
+
+  function ensurePreparedIndex(): { index: IndexProvider } & PreparedIndex {
+    const provider = options.index ?? getRegisteredIndexProvider();
+
+    if (!provider) {
+      throw new Error(
+        '[docusaurus-plugin-smartlinker] No index provider configured. Pass `{ index }` explicitly or make sure the Docusaurus plugin runs before this remark transformer.'
+      );
     }
-  }
 
-  termEntries.sort((a, b) => b.literal.length - a.literal.length);
+    if (provider !== cachedProvider) {
+      const targets = provider.getAllTargets();
 
-  const claimMap = new Map<string, { id: string; slug: string; icon?: string }[]>();
-  for (const t of targets) {
-    for (const lit of t.terms) {
-      const ll = String(lit).toLocaleLowerCase();
-      const arr = claimMap.get(ll) ?? [];
-      arr.push({ id: t.id, slug: t.slug, icon: t.icon });
-      claimMap.set(ll, arr);
+      const termEntries: AutoLinkEntry[] = [];
+      const claimMap = new Map<string, { id: string; slug: string; icon?: string }[]>();
+
+      for (const t of targets) {
+        for (const lit of t.terms) {
+          const literal = String(lit ?? '').trim();
+          if (!literal) continue;
+          termEntries.push({ literal, key: `${t.id}::${t.slug}::${t.icon ?? ''}` });
+
+          const ll = literal.toLocaleLowerCase();
+          const arr = claimMap.get(ll) ?? [];
+          arr.push({ id: t.id, slug: t.slug, icon: t.icon });
+          claimMap.set(ll, arr);
+        }
+      }
+
+      termEntries.sort((a, b) => b.literal.length - a.literal.length);
+      for (const [, arr] of claimMap) arr.sort((a, b) => a.id.localeCompare(b.id));
+
+      const matcher = buildMatcher(termEntries);
+
+      const targetByPath = new Map<string, TargetInfo>();
+      const targetById = new Map<string, TargetInfo>();
+      const targetBySlug = new Map<string, TargetInfo>();
+
+      for (const t of targets) {
+        if (t.sourcePath) {
+          const key = normalizePath(t.sourcePath);
+          if (key) targetByPath.set(key, t);
+        }
+        if (t.id) targetById.set(t.id, t);
+        if (t.slug) targetBySlug.set(t.slug, t);
+      }
+
+      prepared = { targets, matcher, claimMap, targetByPath, targetById, targetBySlug };
+      cachedProvider = provider;
     }
-  }
-  for (const [, arr] of claimMap) arr.sort((a, b) => a.id.localeCompare(b.id));
 
-  const matcher = buildMatcher(termEntries);
-
-  const targetByPath = new Map<string, TargetInfo>();
-  const targetById = new Map<string, TargetInfo>();
-  const targetBySlug = new Map<string, TargetInfo>();
-  for (const t of targets) {
-    if (t.sourcePath) {
-      const key = normalizePath(t.sourcePath);
-      if (key) targetByPath.set(key, t);
-    }
-    if (t.id) targetById.set(t.id, t);
-    if (t.slug) targetBySlug.set(t.slug, t);
+    return { index: provider, ...(prepared as PreparedIndex) };
   }
 
   return (tree: any, file: any) => {
+    const { index, matcher, claimMap, targetByPath, targetById, targetBySlug } = ensurePreparedIndex();
+
     const currentTarget = findCurrentTarget({
       file,
-      index: opts.index,
+      index,
       targetByPath,
       targetById,
       targetBySlug,


### PR DESCRIPTION
## Summary
- mirror the smartlink index provider onto `globalThis` so the bundled remark transformer can pick it up without extra fallback plumbing
- lazily rebuild remark matcher data when the provider changes and cover plugin-managed and missing-index scenarios in tests
- log the change in `AGENT_LOG.md`

## Testing
- npm run build
- npm test
- npm run site:build

------
https://chatgpt.com/codex/tasks/task_e_68cfb8366f4883319d99daf0636e0deb