### PR TITLE
Use pnpm in CI workflow and update dependencies

### DIFF
--- a/.github/workflows/deploy-example-site.yml
+++ b/.github/workflows/deploy-example-site.yml
@@ -26,16 +26,22 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: npm
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
 
       - name: Install dependencies
-        run: npm install
+        run: pnpm install --frozen-lockfile
 
       - name: Build packages
-        run: npm run build
+        run: pnpm run build
 
       - name: Build example site
-        run: npm run site:build
+        run: pnpm run site:build
 
       - name: Configure Pages
         uses: actions/configure-pages@v4

--- a/examples/site/package.json
+++ b/examples/site/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@docusaurus/core": "^3.0.0",
     "@docusaurus/preset-classic": "^3.0.0",
-    "docusaurus-plugin-smartlinker": "file:../..",
+    "docusaurus-plugin-smartlinker": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/packages/docusaurus-plugin-smartlinker/package.json
+++ b/packages/docusaurus-plugin-smartlinker/package.json
@@ -27,6 +27,7 @@
     "environment": "jsdom"
   },
   "devDependencies": {
+    "@docusaurus/plugin-content-docs": "^3.0.0",
     "@testing-library/jest-dom": "^6.8.0",
     "@testing-library/react": "^16.0.0",
     "@testing-library/user-event": "^14.5.2",

--- a/packages/remark-smartlinker/package.json
+++ b/packages/remark-smartlinker/package.json
@@ -20,6 +20,9 @@
     "build": "tsc -p tsconfig.json && node ./scripts/build-cjs.js",
     "test": "vitest run"
   },
+  "dependencies": {
+    "docusaurus-plugin-smartlinker": "workspace:*"
+  },
   "devDependencies": {
     "@types/mdast": "^4.0.4",
     "@types/unist": "^3.0.2",

--- a/packages/remark-smartlinker/tsconfig.json
+++ b/packages/remark-smartlinker/tsconfig.json
@@ -2,6 +2,17 @@
   "extends": "../../tsconfig.base.json",
   "include": ["src"],
   "compilerOptions": {
-    "outDir": "./dist"
+    "outDir": "./dist",
+    "baseUrl": "./",
+    "paths": {
+      "docusaurus-plugin-smartlinker": [
+        "../docusaurus-plugin-smartlinker/dist/index.d.ts",
+        "../docusaurus-plugin-smartlinker/src/index.ts"
+      ],
+      "docusaurus-plugin-smartlinker/*": [
+        "../docusaurus-plugin-smartlinker/dist/*",
+        "../docusaurus-plugin-smartlinker/src/*"
+      ]
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^3.0.0
         version: 3.8.1(@algolia/client-search@5.37.0)(@mdx-js/react@3.1.1(@types/react@19.1.13)(react@18.3.1))(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.2)
       docusaurus-plugin-smartlinker:
-        specifier: file:../..
-        version: file:(@docusaurus/core@3.8.1(@mdx-js/react@3.1.1(@types/react@19.1.13)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2))(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(unified@11.0.5)
+        specifier: workspace:*
+        version: link:../..
       react:
         specifier: '>=18.2.0 <20'
         version: 18.3.1
@@ -117,6 +117,9 @@ importers:
         specifier: ^3.23.0
         version: 3.25.76
     devDependencies:
+      '@docusaurus/plugin-content-docs':
+        specifier: ^3.0.0
+        version: 3.8.1(@mdx-js/react@3.1.1(@types/react@19.1.13)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
       '@testing-library/jest-dom':
         specifier: ^6.8.0
         version: 6.8.0
@@ -132,6 +135,46 @@ importers:
       typescript:
         specifier: ^5.5.4
         version: 5.9.2
+      vitest:
+        specifier: ^2.0.5
+        version: 2.1.9(@types/node@24.3.3)(jsdom@24.1.3)(terser@5.44.0)
+
+  packages/remark-smartlinker:
+    dependencies:
+      docusaurus-plugin-smartlinker:
+        specifier: workspace:*
+        version: link:../..
+    devDependencies:
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
+      '@types/unist':
+        specifier: ^3.0.2
+        version: 3.0.3
+      mdast-util-to-string:
+        specifier: ^4.0.0
+        version: 4.0.0
+      remark-mdx:
+        specifier: ^3.1.1
+        version: 3.1.1
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      remark-stringify:
+        specifier: ^11.0.0
+        version: 11.0.0
+      typescript:
+        specifier: ^5.5.4
+        version: 5.9.2
+      unified:
+        specifier: ^11.0.5
+        version: 11.0.5
+      unist-util-visit:
+        specifier: ^5.0.0
+        version: 5.0.0
+      vfile:
+        specifier: ^6.0.3
+        version: 6.0.3
       vitest:
         specifier: ^2.0.5
         version: 2.1.9(@types/node@24.3.3)(jsdom@24.1.3)(terser@5.44.0)
@@ -2896,15 +2939,6 @@ packages:
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
     engines: {node: '>=6'}
-
-  'docusaurus-plugin-smartlinker@file:':
-    resolution: {directory: '', type: directory}
-    engines: {node: '>=18 <25'}
-    peerDependencies:
-      '@docusaurus/core': ^3.0.0
-      react: '>=18.2.0 <20'
-      react-dom: '>=18.2.0 <20'
-      unified: ^11.0.0
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -9337,29 +9371,6 @@ snapshots:
   dns-packet@5.6.1:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
-
-  docusaurus-plugin-smartlinker@file:(@docusaurus/core@3.8.1(@mdx-js/react@3.1.1(@types/react@19.1.13)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2))(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(unified@11.0.5):
-    dependencies:
-      '@docusaurus/core': 3.8.1(@mdx-js/react@3.1.1(@types/react@19.1.13)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
-      '@docusaurus/mdx-loader': 3.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mdx-js/mdx': 3.1.1
-      '@mdx-js/react': 3.1.1(@types/react@19.1.13)(react@18.3.1)
-      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      gray-matter: 4.0.3
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-markdown: 9.1.0(@types/react@19.1.13)(react@18.3.1)
-      unified: 11.0.5
-      unist-util-visit: 5.0.0
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@types/react'
-      - '@types/react-dom'
-      - esbuild
-      - supports-color
-      - uglify-js
-      - webpack-cli
 
   dom-accessibility-api@0.5.16: {}
 


### PR DESCRIPTION
## Summary
- switch the GitHub Pages workflow to pnpm with proper caching and setup
- add missing Smartlinker build dependencies and TypeScript path mappings
- point the example site to the workspace package and refresh the pnpm lockfile

## Testing
- pnpm run build
- pnpm run site:build

------
https://chatgpt.com/codex/tasks/task_e_68d154450264833183f888096ef9f7c5