### PR TITLE
Add CI workflow for pull request builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,17 +11,17 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
+
       - name: Use Node.js 20
         uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 9.0.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Summary
- add a CI workflow that runs on pull requests and manual dispatch
- install pnpm before running the build to avoid missing executable errors
- ensure pull requests build both the packages and the example site

## Testing
- pnpm install --frozen-lockfile
- pnpm run build

------
https://chatgpt.com/codex/tasks/task_e_68d164d1e44c83318766c60c85bf3e88