### PR TITLE
Fix mobile SmartLink tooltip tap flow

### DIFF
--- a/packages/docusaurus-plugin-smartlinker/src/theme/runtime/SmartLink.tsx
+++ b/packages/docusaurus-plugin-smartlinker/src/theme/runtime/SmartLink.tsx
@@ -15,7 +15,7 @@ export interface SmartLinkProps extends React.PropsWithChildren {
 /**
  * Behavior:
  * - Desktop: Hover over text shows tooltip; click on text or icon navigates.
- * - Mobile: Tap on icon toggles tooltip; tap on text navigates.
+ * - Mobile: First tap on link (text or icon) shows tooltip; second tap navigates.
  * Rendering: icon AFTER text.
  */
 export default function SmartLink({ to, children, tipKey, icon, match }: SmartLinkProps) {
@@ -40,19 +40,31 @@ export default function SmartLink({ to, children, tipKey, icon, match }: SmartLi
     return () => mq?.removeEventListener?.('change', onChange);
   }, []);
 
-  // Controlled open state for mobile (icon tap)
+  // Controlled open state for mobile (link tap)
   const [open, setOpen] = React.useState(false);
-  const toggleOpen = React.useCallback(() => setOpen(v => !v), []);
   const close = React.useCallback(() => setOpen(false), []);
 
   // Tooltip content: render ShortNote if available; otherwise no tooltip
   const content = Short ? <Short components={mdxComponents} /> : undefined;
+  const hasTooltip = Boolean(content);
 
-  // Anchor onClick should close tooltip on navigation
-  const onAnchorClick: React.MouseEventHandler<HTMLAnchorElement> = () => {
-    // allow navigation; just close
-    setOpen(false);
-  };
+  // On mobile, first tap opens tooltip; second tap navigates.
+  const handleLinkClick = React.useCallback<
+    React.MouseEventHandler<HTMLAnchorElement>
+  >(
+    (event) => {
+      if (!isHoverCapable && hasTooltip && !open) {
+        event.preventDefault();
+        event.stopPropagation();
+        setOpen(true);
+        return;
+      }
+
+      // Allow navigation, but ensure tooltip is closed for subsequent renders.
+      setOpen(false);
+    },
+    [hasTooltip, isHoverCapable, open],
+  );
 
   // Icon button for mobile toggle (but clickable to navigate as well on desktop)
   const textNode = (
@@ -60,7 +72,7 @@ export default function SmartLink({ to, children, tipKey, icon, match }: SmartLi
       href={resolvedHref}
       className="lm-smartlink__anchor"
       data-tipkey={tipKey ?? undefined}
-      onClick={onAnchorClick}
+      onClick={handleLinkClick}
     >
       <span className="lm-smartlink__text">{children}</span>
     </a>
@@ -77,15 +89,7 @@ export default function SmartLink({ to, children, tipKey, icon, match }: SmartLi
     <a
       href={resolvedHref}
       className="lm-smartlink__iconlink"
-      onClick={(e) => {
-        if (!isHoverCapable && content) {
-          e.preventDefault();
-          e.stopPropagation();
-          toggleOpen();
-          return;
-        }
-        onAnchorClick(e);
-      }}
+      onClick={handleLinkClick}
       onFocus={!isHoverCapable ? undefined : close}
       tabIndex={isHoverCapable ? -1 : 0}
       aria-hidden={isHoverCapable ? true : undefined}


### PR DESCRIPTION
## Summary
- show SmartLink tooltips on the first tap for touch-only devices and navigate on the second tap
- share the same mobile tap handler for both the text link and icon trigger

## Testing
- not run (per request)