### PR TITLE
chore: enforce pnpm workflows and verify publish artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,18 @@
 name: CI
 
 on:
+  push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 
 jobs:
-  build:
+  verify:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [20.x]
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -16,18 +22,35 @@ jobs:
         with:
           version: 9.0.0
 
-      - name: Use Node.js 20
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: ${{ matrix.node-version }}
           cache: pnpm
           cache-dependency-path: pnpm-lock.yaml
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build packages
-        run: pnpm run build
+      - name: Typecheck
+        run: pnpm typecheck
 
-      - name: Build example site
-        run: pnpm run site:build
+      - name: Build & test
+        run: pnpm test
+
+      - name: Create publishable tarball
+        run: pnpm run pack:ci
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist-${{ matrix.node-version }}
+          path: |
+            packages/docusaurus-plugin-smartlinker/dist
+            packages/remark-smartlinker/dist
+
+      - name: Upload package tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: package-tarball-${{ matrix.node-version }}
+          path: build-artifacts/*.tgz

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Smartlinker is a Docusaurus v3 plugin (with an optional remark helper) that turn
 1) Install
 
 ```bash
-npm install github:Uli-Z/docusaurus-plugin-smartlinker
+pnpm add github:Uli-Z/docusaurus-plugin-smartlinker
 ```
 
 2) Register (plugin + remark) in `docusaurus.config`
@@ -117,6 +117,22 @@ Override any of the `--lm-*` variables in your site CSS to customize appearances
 
 - Live demo: https://uli-z.github.io/docusaurus-plugin-smartlinker/docs/demo
 - Example site in this repo under `examples/site`.
+
+## Local development (pnpm only)
+
+This repository is pnpm-first. To work on the plugin locally:
+
+```bash
+pnpm install
+pnpm build          # builds both the plugin and remark helper
+CI=1 pnpm test      # runs unit + integration tests (including the example site build)
+pnpm run pack:ci    # produces a tarball under build-artifacts/
+```
+
+Useful extras:
+
+- `pnpm typecheck` – runs `tsc --noEmit` for both workspaces.
+- `pnpm site:build` – builds the example Docusaurus site from source.
 
 ## License
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,7 @@
 - Remove legacy linkify-med artifacts and stale lockfile entries.
 - Drop npm lockfile in favor of pnpm.
 - Keep package dist directories tracked.
+- Adopt pnpm-only build/test scripts, new artifact verification, and CI automation that packs the plugin and builds the example site.
 
 This is the first, provisional release of Smartlinker for Docusaurus v3. It ships the core experience: annotate docs via front matter, and Smartlinker turns matching terms across your site into links with contextual MDX tooltips and icons.
 

--- a/agent_log.md
+++ b/agent_log.md
@@ -1,10 +1,11 @@
 # Log
 
 ## Summary
-- Replaced SmartLink/Tooltip base styles with Infima-backed variables and state rules, dropping bespoke inheritance overrides.
-- Updated tooltip runtime to push the max-width through a CSS custom property so the stylesheet can control it via Infima tokens.
-- Documented the new token mapping and kept CHANGELOG notes for the alignment work.
+- Replaced npm-based workspace scripts with pnpm equivalents, including new `typecheck`, `ci`, and `pack:ci` flows.
+- Updated integration tests to package the plugin tarball, install it into a copied example site via pnpm, and assert dist contents and site build success with reduced progress noise.
+- Added a Vitest alias so remark tests resolve the built plugin dist, and documented the pnpm-first workflow (README, release notes, changelog).
 
 ## Verification
-- pnpm build
-- pnpm test
+- pnpm typecheck
+- CI=1 pnpm test
+- pnpm run pack:ci

--- a/agent_plan.md
+++ b/agent_plan.md
@@ -1,5 +1,46 @@
 # Plan
 
-1. Review the SmartLink + Tooltip markup/CSS to spot where they bypass Infima tokens/utilities.
-2. Refactor the styles to lean on Infima variables (spacing, color, transitions) and adjust the tooltip runtime so width is driven via CSS custom properties.
-3. Update docs/logs with the new token mapping and run the build/tests to confirm the packaged output.
+## Goals
+- Ensure the packages build, test, and pack correctly using **pnpm** only.
+- Produce distributable artifacts (`dist/` JS + types + assets) for both plugin and remark helper, and guarantee they are published.
+- Provide automated validation (unit + integration) and CI pipeline mirroring local workflow, including an example Docusaurus site smoke test.
+
+## Implementation Outline
+1. **Baseline & Analysis**
+   - Record current Node/pnpm versions and run `pnpm install`, `pnpm build`, `pnpm test` to capture existing issues in `agent_log.md`.
+   - Inspect existing build outputs and packaging rules to understand gaps (missing dist, tarball content, etc.).
+
+2. **Tooling & Scripts**
+   - Convert workspace scripts to `pnpm` equivalents (use recursive/filtered commands) and remove npm-specific scripts.
+   - Introduce shared scripts (e.g., `pnpm run -r build`, `pnpm lint`, `pnpm test`, `pnpm typecheck`, `pnpm pack:verify`).
+   - Ensure consistent TypeScript configs, incremental builds, and source maps; set up bundler (`tsc` + helper) as needed.
+
+3. **Build Output Guarantees**
+   - Standardize each package's build pipeline (likely `tsup` or `tsc` + copy assets) to emit `dist/` with both ESM & CJS (if required), and type declarations.
+   - Add post-build checks ensuring expected files (JS, d.ts, CSS) exist; fail build otherwise.
+   - Update `files`, `exports`, and supporting configs so `pnpm pack` includes dist outputs only (no src/tests).
+
+4. **Integration Testing**
+   - Author automated tests that:
+     - Run the build and assert `dist/` contains required files.
+     - Inspect `pnpm pack` tarball to verify packaged files.
+     - Use a minimal example Docusaurus site that installs the tarball and runs a production build (headless) to confirm plugin integration.
+   - Update existing unit tests / vitest configuration to align with pnpm workspace.
+
+5. **CI Pipeline**
+   - Create `.github/workflows/ci.yml` using `actions/setup-node` + `pnpm/action-setup`, caching pnpm store.
+   - CI steps: install, lint/typecheck (if applicable), build, test, pack verification, example site build.
+   - Upload `dist/` and packed tarball as artifacts; ensure workflow fails if build outputs missing.
+
+6. **Docs & Logs**
+   - Update `README`, `CHANGELOG`, and `agent_log.md` with new workflow, commands, and findings.
+   - Document usage instructions (pnpm only) and CI details.
+
+## Test Plan
+- `pnpm install`
+- `pnpm build`
+- `pnpm test`
+- `pnpm run lint` / `pnpm typecheck` (if added)
+- `pnpm pack` (root) with custom verification script
+- Example site build command (e.g., `pnpm --filter @examples/site build`)
+- Any new integration test commands (e.g., `pnpm run verify:artifacts`, `pnpm run test:integration`)

--- a/package.json
+++ b/package.json
@@ -34,14 +34,17 @@
     "packages/remark-smartlinker/dist"
   ],
   "scripts": {
-    "build": "npm run build --workspace=@internal/docusaurus-plugin-smartlinker --workspace=@internal/remark-smartlinker",
-    "test": "npm run test --workspace=@internal/docusaurus-plugin-smartlinker --workspace=@internal/remark-smartlinker",
+    "build": "pnpm --filter @internal/docusaurus-plugin-smartlinker run build && pnpm --filter @internal/remark-smartlinker run build",
+    "test": "pnpm build && pnpm --filter @internal/docusaurus-plugin-smartlinker run test && pnpm --filter @internal/remark-smartlinker run test",
+    "typecheck": "pnpm --filter @internal/docusaurus-plugin-smartlinker run typecheck && pnpm --filter @internal/remark-smartlinker run typecheck",
     "lint": "echo \"@(optional) add eslint later\"",
-    "site:dev": "npm run dev --workspace @examples/site",
-    "site:build": "npm run build --workspace @examples/site",
-    "site:serve": "npm run serve --workspace @examples/site",
-    "reset": "rm -rf node_modules packages/*/node_modules examples/site/node_modules && npm install && npm run build && npm run build --workspace @examples/site",
-    "prepublishOnly": "npm run build",
+    "ci": "pnpm test && pnpm run pack:ci",
+    "site:dev": "pnpm --filter @examples/site run dev",
+    "site:build": "pnpm --filter @examples/site run build",
+    "site:serve": "pnpm --filter @examples/site run serve",
+    "pack:ci": "node -e \"require('fs').rmSync('build-artifacts', { recursive: true, force: true });\" && pnpm pack --pack-destination build-artifacts",
+    "reset": "rm -rf node_modules packages/*/node_modules examples/site/node_modules && pnpm install && pnpm build && pnpm --filter @examples/site run build",
+    "prepublishOnly": "pnpm build",
     "smoke:git-install": "node ./scripts/git-install-smoke.mjs"
   },
   "peerDependencies": {

--- a/packages/docusaurus-plugin-smartlinker/CHANGELOG.md
+++ b/packages/docusaurus-plugin-smartlinker/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Align SmartLink tooltip/link styling with Infima tokens and expose `--lm-*` overrides while documenting the remaining bespoke defaults.
+- Switched workspace scripts and integration tests to pnpm, added example-site packaging checks, and aliased remark tests to the built plugin dist.
 
 ## 0.1.0 — Initial preview
 

--- a/packages/docusaurus-plugin-smartlinker/package.json
+++ b/packages/docusaurus-plugin-smartlinker/package.json
@@ -21,7 +21,8 @@
   ],
   "scripts": {
     "build": "node -e \"require('fs').rmSync('dist', {recursive: true, force: true});\" && tsc -p tsconfig.json && node ./scripts/postbuild-verify.mjs",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "vitest": {
     "environment": "jsdom"

--- a/packages/docusaurus-plugin-smartlinker/tests/example.build.e2e.test.ts
+++ b/packages/docusaurus-plugin-smartlinker/tests/example.build.e2e.test.ts
@@ -1,24 +1,132 @@
-import { describe, it, beforeAll, expect } from 'vitest';
-import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { describe, it, beforeAll, afterAll, expect } from 'vitest';
+import { execFileSync, type ExecFileSyncOptionsWithStringEncoding } from 'node:child_process';
+import { readFileSync, mkdtempSync, rmSync, writeFileSync, cpSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, relative, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, '..', '..', '..');
 const siteDir = join(repoRoot, 'examples', 'site');
+const pluginDistDir = join(repoRoot, 'packages', 'docusaurus-plugin-smartlinker', 'dist');
+const remarkDistDir = join(repoRoot, 'packages', 'remark-smartlinker', 'dist');
+
+const disallowedTokens = ['node_modules', 'build', '.docusaurus'];
+
+function filterSiteCopy(src) {
+  const relativePath = relative(siteDir, src);
+  if (!relativePath || relativePath.startsWith('..')) {
+    return true;
+  }
+  const segments = relativePath.split(/[\\/]/);
+  return !segments.some((segment) => disallowedTokens.includes(segment));
+}
+
+let tempRoot;
+let tarballPath;
+let packedSiteDir;
+let tarballEntries;
+
+function run(command: string, args: string[], options?: ExecFileSyncOptionsWithStringEncoding): string {
+  try {
+    return execFileSync(command, args, {
+      encoding: 'utf8',
+      stdio: 'pipe',
+      ...options,
+    });
+  } catch (error: any) {
+    if (error?.stdout) {
+      process.stdout.write(error.stdout);
+    }
+    if (error?.stderr) {
+      process.stderr.write(error.stderr);
+    }
+    throw error;
+  }
+}
 
 beforeAll(() => {
-  execFileSync('npm', ['run', 'site:build'], {
+  tempRoot = mkdtempSync(join(tmpdir(), 'smartlinker-example-'));
+  const packOutput = run('pnpm', ['pack', '--pack-destination', tempRoot], {
     cwd: repoRoot,
-    env: { ...process.env, CI: '1' },
-    stdio: 'inherit',
   });
-}, 180_000);
+  const packLines = packOutput.trim().split(/\r?\n/).filter(Boolean);
+  const tarballName = packLines[packLines.length - 1];
+  tarballPath = resolve(tempRoot, tarballName);
+
+  packedSiteDir = join(tempRoot, 'site');
+  cpSync(siteDir, packedSiteDir, { recursive: true, filter: filterSiteCopy });
+
+  const pkgJsonPath = join(packedSiteDir, 'package.json');
+  const pkg = JSON.parse(readFileSync(pkgJsonPath, 'utf8'));
+  const relativeTarball = relative(packedSiteDir, tarballPath);
+  pkg.dependencies = pkg.dependencies ?? {};
+  pkg.dependencies['docusaurus-plugin-smartlinker'] = `file:${relativeTarball}`;
+  writeFileSync(pkgJsonPath, `${JSON.stringify(pkg, null, 2)}\n`);
+
+  run('pnpm', ['install', '--frozen-lockfile=false', '--reporter=silent'], {
+    cwd: packedSiteDir,
+  });
+  console.info('Installed example site dependencies via pnpm');
+
+  run('pnpm', ['exec', 'docusaurus', 'build'], {
+    cwd: packedSiteDir,
+    env: { ...process.env, CI: '1', FORCE_COLOR: '0', TERM: 'dumb' },
+  });
+  console.info('Built example site with packed plugin');
+
+  const tarListing = run('tar', ['-tf', tarballPath]);
+  tarballEntries = tarListing.trim().split(/\r?\n/);
+}, 360_000);
+
+afterAll(() => {
+  if (tempRoot) {
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
+});
 
 describe('example site build', () => {
+  it('builds plugin dist before packaging', () => {
+    const files = [
+      'index.js',
+      'index.d.ts',
+      'theme/index.js',
+      'theme/styles.css',
+      'theme/runtime/Root.js',
+      'theme/runtime/SmartLink.js',
+      'theme/runtime/Tooltip.js',
+      'theme/runtime/IconResolver.js',
+      'theme/runtime/context.js',
+    ];
+    for (const file of files) {
+      const absolute = join(pluginDistDir, file);
+      const contents = readFileSync(absolute, 'utf8');
+      expect(contents.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('builds remark dist before packaging', () => {
+    const files = ['index.js', 'index.d.ts', 'index.cjs'];
+    for (const file of files) {
+      const absolute = join(remarkDistDir, file);
+      const contents = readFileSync(absolute, 'utf8');
+      expect(contents.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('includes dist files in the packed tarball', () => {
+    expect(tarballEntries).toEqual(expect.arrayContaining([
+      'package/packages/docusaurus-plugin-smartlinker/dist/index.js',
+      'package/packages/docusaurus-plugin-smartlinker/dist/index.d.ts',
+      'package/packages/docusaurus-plugin-smartlinker/dist/theme/styles.css',
+      'package/packages/remark-smartlinker/dist/index.js',
+      'package/packages/remark-smartlinker/dist/index.d.ts',
+      'package/packages/remark-smartlinker/dist/index.cjs',
+    ]));
+  });
+
   it('emits SmartLinks with Docusaurus-resolved hrefs', () => {
-    const html = readFileSync(join(siteDir, 'build', 'docs', 'demo', 'index.html'), 'utf8');
+    const html = readFileSync(join(packedSiteDir, 'build', 'docs', 'demo', 'index.html'), 'utf8');
     expect(html).toContain('href="/docs/antibiotics/amoxicillin"');
     expect(html).toContain('href="/docs/antibiotics/piperacillin-tazobactam"');
   });

--- a/packages/remark-smartlinker/CHANGELOG.md
+++ b/packages/remark-smartlinker/CHANGELOG.md
@@ -9,5 +9,9 @@ Highlights
 - Remark transform that injects `<SmartLink/>` nodes, while skipping code, inline code, existing links/images, and top‑level headings.
 - Pairs out‑of‑the‑box with the Docusaurus plugin; can also be used in Docusaurus classic preset pipelines.
 
+Unreleased
+
+- Vitest now resolves `docusaurus-plugin-smartlinker` to the built dist, keeping remark tests green after pnpm-based build steps.
+
 Notes
 - Interfaces and configuration may change during 0.1.x as the plugin stabilizes.

--- a/packages/remark-smartlinker/package.json
+++ b/packages/remark-smartlinker/package.json
@@ -18,7 +18,8 @@
   ],
   "scripts": {
     "build": "tsc -p tsconfig.json && node ./scripts/build-cjs.js",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
     "docusaurus-plugin-smartlinker": "file:../.."

--- a/packages/remark-smartlinker/vitest.config.ts
+++ b/packages/remark-smartlinker/vitest.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from 'vitest/config';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pluginDistEntry = join(__dirname, '..', 'docusaurus-plugin-smartlinker', 'dist', 'index.js');
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      'docusaurus-plugin-smartlinker': pluginDistEntry,
+    },
+  },
+});

--- a/scripts/git-install-smoke.mjs
+++ b/scripts/git-install-smoke.mjs
@@ -1,28 +1,15 @@
 #!/usr/bin/env node
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'node:fs';
 import { cpSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { dirname, join, resolve, sep } from 'node:path';
+import { dirname, join, resolve, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const run = (command, options = {}) => {
-  const { env: optionEnv, ...rest } = options;
+const runPnpm = (args, options = {}) => {
+  const { env: optionEnv, stdio = 'inherit', ...rest } = options;
   const env = { ...process.env, ...optionEnv };
-  execSync(command, { stdio: 'inherit', ...rest, env });
-};
-
-const runJsonArray = (command, options = {}) => {
-  const { env: optionEnv, ...rest } = options;
-  const env = { ...process.env, ...optionEnv };
-  const raw = execSync(command, { stdio: 'pipe', encoding: 'utf8', ...rest, env });
-  const start = raw.indexOf('[');
-  const end = raw.lastIndexOf(']');
-  if (start === -1 || end === -1 || end <= start) {
-    throw new Error(`Failed to parse JSON output from command: ${command}`);
-  }
-  const jsonSlice = raw.slice(start, end + 1);
-  return JSON.parse(jsonSlice);
+  return execFileSync('pnpm', args, { stdio, ...rest, env });
 };
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -31,17 +18,24 @@ const exampleDir = join(rootDir, 'examples', 'site');
 
 let tarballPath;
 let tempDir;
+let packDir;
 
 try {
   console.log('▶ Building workspaces before packing...');
-  run('npm run build', { cwd: rootDir, env: { npm_config_loglevel: 'error', npm_config_progress: 'false' } });
+  runPnpm(['build'], { cwd: rootDir });
 
   console.log('▶ Packing repository...');
-  const packEntries = runJsonArray('npm pack --json', { cwd: rootDir, env: { npm_config_loglevel: 'error', npm_config_progress: 'false' } });
-  if (packEntries.length === 0) {
-    throw new Error('npm pack did not return a filename');
+  packDir = mkdtempSync(join(tmpdir(), 'smartlinker-pack-'));
+  const packOutput = runPnpm(['pack', '--pack-destination', packDir], {
+    cwd: rootDir,
+    stdio: 'pipe',
+    env: { ...process.env },
+  });
+  const packLines = packOutput.toString('utf8').trim().split(/\r?\n/).filter(Boolean);
+  if (packLines.length === 0) {
+    throw new Error('pnpm pack did not return a filename');
   }
-  tarballPath = join(rootDir, packEntries[0].filename);
+  tarballPath = join(packDir, packLines[packLines.length - 1]);
 
   tempDir = mkdtempSync(join(tmpdir(), 'smartlinker-smoke-'));
   const siteDir = join(tempDir, 'site');
@@ -67,17 +61,15 @@ try {
   const pkgPath = join(siteDir, 'package.json');
   const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
   pkg.dependencies = pkg.dependencies || {};
-  pkg.dependencies['docusaurus-plugin-smartlinker'] = `file:${tarballPath}`;
+  const relativeTarball = `file:${relative(siteDir, tarballPath)}`;
+  pkg.dependencies['docusaurus-plugin-smartlinker'] = relativeTarball;
   writeFileSync(pkgPath, `${JSON.stringify(pkg, null, 2)}\n`);
 
-  console.log('▶ Installing dependencies via npm...');
-  run('npm install', {
-    cwd: siteDir,
-    env: { npm_config_loglevel: 'error', npm_config_progress: 'false', npm_config_fund: 'false' },
-  });
+  console.log('▶ Installing dependencies via pnpm...');
+  runPnpm(['install'], { cwd: siteDir });
 
   console.log('▶ Running docusaurus build in smoke environment...');
-  run('npm run build', { cwd: siteDir, env: { npm_config_loglevel: 'error', npm_config_progress: 'false' } });
+  runPnpm(['run', 'build'], { cwd: siteDir, env: { CI: '1' } });
 
   console.log('\n✔ Git install smoke test succeeded. Build output located at:', join(siteDir, 'build'));
 } finally {
@@ -86,5 +78,8 @@ try {
   }
   if (tarballPath) {
     rmSync(tarballPath, { force: true });
+  }
+  if (packDir) {
+    rmSync(packDir, { recursive: true, force: true });
   }
 }


### PR DESCRIPTION
## Summary
- replace npm-based scripts with pnpm equivalents, add typecheck/ci/pack helpers, and update git-install smoke script
- extend vitest integration to pack the plugin tarball, install it into a copied example site with pnpm, and assert dist contents
- add a remark workspace vitest alias plus docs/changelog updates outlining the pnpm-first workflow and new CI pipeline

## Testing
- pnpm typecheck
- CI=1 pnpm test
- pnpm run pack:ci

------
https://chatgpt.com/codex/tasks/task_e_68d7c76b6e5883318733b50a2d656b2c