### PR TITLE
Use workspace dependency for example site

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,12 @@ jobs:
       - name: Build & test
         run: pnpm test
 
+      - name: Build packages
+        run: pnpm run build
+
+      - name: Build example site
+        run: pnpm run site:build
+
       - name: Create publishable tarball
         run: pnpm run pack:ci
 

--- a/examples/site/package.json
+++ b/examples/site/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@docusaurus/core": "^3.0.0",
     "@docusaurus/preset-classic": "^3.0.0",
-    "docusaurus-plugin-smartlinker": "file:../../",
+    "docusaurus-plugin-smartlinker": "workspace:*",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   }

--- a/packages/remark-smartlinker/package.json
+++ b/packages/remark-smartlinker/package.json
@@ -22,7 +22,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "docusaurus-plugin-smartlinker": "file:../.."
+    "docusaurus-plugin-smartlinker": "workspace:*"
   },
   "devDependencies": {
     "@types/mdast": "^4.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^3.0.0
         version: 3.8.1(@algolia/client-search@5.37.0)(@mdx-js/react@3.1.1(@types/react@19.1.13)(react@18.3.1))(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.9.2)
       docusaurus-plugin-smartlinker:
-        specifier: file:../../
-        version: file:(@docusaurus/core@3.8.1(@mdx-js/react@3.1.1(@types/react@19.1.13)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2))(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(unified@11.0.5)
+        specifier: workspace:*
+        version: link:../..
       react:
         specifier: '>=18.2.0 <20'
         version: 18.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ importers:
   packages/remark-smartlinker:
     dependencies:
       docusaurus-plugin-smartlinker:
-        specifier: file:../..
-        version: file:(@docusaurus/core@3.8.1(@mdx-js/react@3.1.1(@types/react@19.1.13)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2))(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(unified@11.0.5)
+        specifier: workspace:*
+        version: link:../..
     devDependencies:
       '@types/mdast':
         specifier: ^4.0.4
@@ -2939,15 +2939,6 @@ packages:
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
     engines: {node: '>=6'}
-
-  'docusaurus-plugin-smartlinker@file:':
-    resolution: {directory: '', type: directory}
-    engines: {node: '>=18 <25'}
-    peerDependencies:
-      '@docusaurus/core': ^3.0.0
-      react: '>=18.2.0 <20'
-      react-dom: '>=18.2.0 <20'
-      unified: ^11.0.0
 
   dom-accessibility-api@0.5.16:
     resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
@@ -9380,29 +9371,6 @@ snapshots:
   dns-packet@5.6.1:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
-
-  docusaurus-plugin-smartlinker@file:(@docusaurus/core@3.8.1(@mdx-js/react@3.1.1(@types/react@19.1.13)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2))(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(unified@11.0.5):
-    dependencies:
-      '@docusaurus/core': 3.8.1(@mdx-js/react@3.1.1(@types/react@19.1.13)(react@18.3.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)
-      '@docusaurus/mdx-loader': 3.8.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@mdx-js/mdx': 3.1.1
-      '@mdx-js/react': 3.1.1(@types/react@19.1.13)(react@18.3.1)
-      '@radix-ui/react-tooltip': 1.2.8(@types/react-dom@19.1.9(@types/react@19.1.13))(@types/react@19.1.13)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      gray-matter: 4.0.3
-      react: 18.3.1
-      react-dom: 18.3.1(react@18.3.1)
-      react-markdown: 9.1.0(@types/react@19.1.13)(react@18.3.1)
-      unified: 11.0.5
-      unist-util-visit: 5.0.0
-      zod: 3.25.76
-    transitivePeerDependencies:
-      - '@swc/core'
-      - '@types/react'
-      - '@types/react-dom'
-      - esbuild
-      - supports-color
-      - uglify-js
-      - webpack-cli
 
   dom-accessibility-api@0.5.16: {}
 


### PR DESCRIPTION
## Summary
- point the example site to the workspace version of the plugin so the built dist is always available during CI builds

## Testing
- pnpm typecheck
- pnpm test
- pnpm run build
- pnpm run site:build

------
https://chatgpt.com/codex/tasks/task_e_68d7d7ef57d08331b3ae26667f2283ba