### PR TITLE
Adjust example site debug level for CI

### DIFF
--- a/examples/site/docusaurus.config.ts
+++ b/examples/site/docusaurus.config.ts
@@ -30,6 +30,24 @@ const normalizedBaseUrl = (() => {
   return '/';
 })();
 
+type DebugLevel = 'error' | 'warn' | 'info' | 'debug' | 'trace';
+
+const resolveDebugLevel = (): DebugLevel => {
+  const envLevelRaw = process.env.DOCUSAURUS_PLUGIN_DEBUG_LEVEL?.trim();
+  if (envLevelRaw) {
+    const envLevel = envLevelRaw.toLowerCase();
+    if (['error', 'warn', 'info', 'debug', 'trace'].includes(envLevel)) {
+      return envLevel as DebugLevel;
+    }
+  }
+
+  if (process.env.CI === 'true' || process.env.NODE_ENV === 'test') {
+    return 'error';
+  }
+
+  return 'trace';
+};
+
 const config: Config = {
   title: 'Smartlinker Example',
   favicon: 'img/favicon.ico',
@@ -82,7 +100,7 @@ const config: Config = {
       ],
       debug: {
         enabled: true,
-        level: 'trace',
+        level: resolveDebugLevel(),
       },
     }]
   ],


### PR DESCRIPTION
## Summary
- add a helper to compute the Smartlinker debug level for the example site
- default the debug level to `error` when running in CI or tests while allowing overrides via `DOCUSAURUS_PLUGIN_DEBUG_LEVEL`

## Testing
- pnpm --filter @examples/site run build *(fails: requires prebuilt plugin packages in example workspace)*

------
https://chatgpt.com/codex/tasks/task_e_68d7defb8818833196ab2156fa40f7c6