### PR TITLE
Automate dist artifact publishing via CI

### DIFF
--- a/.github/workflows/publish-dist.yml
+++ b/.github/workflows/publish-dist.yml
@@ -1,0 +1,48 @@
+name: Build dist artifacts
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build-and-commit:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.0.0
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build packages
+        run: pnpm run build
+
+      - name: Commit generated dist directories
+        uses: stefanzweifel/git-auto-commit-action@v5
+        with:
+          commit_message: "chore: update dist artifacts"
+          commit_user_name: GitHub Actions
+          commit_user_email: actions@github.com
+          push_options: '--no-verify'
+          file_pattern: |
+            packages/docusaurus-plugin-smartlinker/dist/**/*
+            packages/remark-smartlinker/dist/**/*

--- a/README.md
+++ b/README.md
@@ -134,6 +134,14 @@ Useful extras:
 - `pnpm typecheck` – runs `tsc --noEmit` for both workspaces.
 - `pnpm site:build` – builds the example Docusaurus site from source.
 
+## Continuous integration
+
+- `.github/workflows/ci.yml` runs type-checking, builds/tests every workspace, packs the repository, and uploads the resulting
+  artifacts.
+- `.github/workflows/publish-dist.yml` rebuilds the plugin and remark helper after every push to `main` (and on demand) and
+  commits the generated `packages/*/dist` output back to the repository via GitHub Actions so Git-based installs always receive
+  compiled code.
+
 ## License
 
 MIT — see [LICENSE](./LICENSE).


### PR DESCRIPTION
## Summary
- add a dedicated `publish-dist` workflow that rebuilds the plugin/remark packages and commits their dist outputs on pushes to `main`
- document the new CI responsibilities in the README for future contributors
- drop the previously checked-in dist directories so they will now be generated exclusively by automation

## Testing
- CI=1 pnpm --filter @internal/docusaurus-plugin-smartlinker run test
- CI=1 pnpm --filter @internal/remark-smartlinker run test

------
https://chatgpt.com/codex/tasks/task_e_68d7e3b6217c8331ad55e45ba4af0cf2